### PR TITLE
Added better rendering support for RMS2

### DIFF
--- a/browedit/components/RsmRenderer.h
+++ b/browedit/components/RsmRenderer.h
@@ -76,7 +76,7 @@ public:
 	void begin();
 	virtual void render();
 	void initMeshInfo(Rsm::Mesh* mesh, const glm::mat4& matrix = glm::mat4(1.0f));
-	void renderMesh(Rsm::Mesh* mesh, const glm::mat4& matrix, bool selectionPhase = false);
+	void renderMesh(Rsm::Mesh* mesh, const glm::mat4& matrix, bool selectionPhase = false, bool calcMatrix = true);
 	
 	virtual bool shouldRender(int phase) { return phase == 0 ? !selected : selected; }
 


### PR DESCRIPTION
- RSM2 version 0x203 now uses animLen for all the mesh transformations rather than the last frame.
- Added support for scale and position transformation frames.
- Changed the rotation quaternion mixing to slerp for RSM2 (may want to change it for RSM1 as well?).
- Currently, the matrices are always recalculated for RSM2, which is not optimal.