### PR TITLE
Fix crashing on fill select and retangle select on new maps (lightmap…

### DIFF
--- a/browedit/MapView.Texturemode.cpp
+++ b/browedit/MapView.Texturemode.cpp
@@ -535,7 +535,7 @@ void MapView::postRenderTextureMode(BrowEdit* browEdit)
 
 
 							t->color = glm::ivec4(255, 255, 255, 255);
-							t->lightmapIndex = -1;
+							t->lightmapIndex = 0;
 							t->textureIndex = textureSelected;
 
 							if (cube->tileUp != -1)
@@ -965,7 +965,7 @@ void MapView::postRenderTextureMode(BrowEdit* browEdit)
 				t->v4.y = 1.0f - t->v4.y;
 
 				t->color = glm::ivec4(255, 255, 255, 255);
-				t->lightmapIndex = -1;
+				t->lightmapIndex = 0;
 				t->textureIndex = textureSelected;
 
 				if (cube->tileUp != -1)


### PR DESCRIPTION
On empty tiles (newly created map), fill and retangle brushs make lightmapIndex = -1, that is causing the program to exit due to an assert within GndRenderer::Chunk::rebuild().