### PR TITLE
Fix for sun lighting on maps

### DIFF
--- a/browedit/components/GndRenderer.cpp
+++ b/browedit/components/GndRenderer.cpp
@@ -114,10 +114,11 @@ void GndRenderer::render()
 	shader->setUniform(GndShader::Uniforms::ModelViewMatrix, dynamic_cast<GndRenderContext*>(renderContext)->viewMatrix);
 
 
-	glm::vec3 lightDirection;
-	lightDirection[0] = -glm::cos(glm::radians((float)rsw->light.longitude)) * glm::sin(glm::radians((float)rsw->light.latitude));
-	lightDirection[1] = glm::cos(glm::radians((float)rsw->light.latitude));
-	lightDirection[2] = glm::sin(glm::radians((float)rsw->light.longitude)) * glm::sin(glm::radians((float)rsw->light.latitude));
+	glm::vec3 lightDirection(0.0f, 1.0f, 0.0f);
+	glm::mat4 rot = glm::mat4(1.0f);
+	rot = glm::rotate(rot, glm::radians(-(float)rsw->light.latitude), glm::vec3(1, 0, 0));
+	rot = glm::rotate(rot, glm::radians((float)rsw->light.longitude), glm::vec3(0, 1, 0));
+	lightDirection = lightDirection * glm::mat3(rot);
 	shader->setUniform(GndShader::Uniforms::lightAmbient, rsw->light.ambient);
 	shader->setUniform(GndShader::Uniforms::lightDiffuse, rsw->light.diffuse);
 	shader->setUniform(GndShader::Uniforms::lightDirection, lightDirection);

--- a/browedit/components/RsmRenderer.cpp
+++ b/browedit/components/RsmRenderer.cpp
@@ -143,9 +143,10 @@ void RsmRenderer::render()
 	glm::vec3 lightDirection(1,1,1);
 	if (rsw)
 	{
-		lightDirection[0] = -glm::cos(glm::radians((float)rsw->light.longitude)) * glm::sin(glm::radians((float)rsw->light.latitude));
-		lightDirection[1] = glm::cos(glm::radians((float)rsw->light.latitude));
-		lightDirection[2] = glm::sin(glm::radians((float)rsw->light.longitude)) * glm::sin(glm::radians((float)rsw->light.latitude));
+		glm::mat4 rot = glm::mat4(1.0f);
+		rot = glm::rotate(rot, glm::radians(-(float)rsw->light.latitude), glm::vec3(1, 0, 0));
+		rot = glm::rotate(rot, glm::radians((float)rsw->light.longitude), glm::vec3(0, 1, 0));
+		lightDirection = glm::vec3(0.0f, 1.0f, 0.0f) * glm::mat3(rot);
 		shader->setUniform(RsmShader::Uniforms::lightAmbient, rsw->light.ambient);
 		shader->setUniform(RsmShader::Uniforms::lightDiffuse, rsw->light.diffuse);
 		shader->setUniform(RsmShader::Uniforms::lightIntensity, rsw->light.intensity);

--- a/data/shaders/gnd.fs
+++ b/data/shaders/gnd.fs
@@ -35,13 +35,11 @@ void main()
 	texture = mix(vec4(1,1,1,texColor.a), texColor, viewTextures);
 	if(texture.a < 0.1)
 		discard;
-
+	
+	texture.rgb *= max((max(0.0, dot(normal, vec3(1,-1,1)*lightDirection)) * lightDiffuse + lightIntensity * lightAmbient), lightToggle);
 	texture.rgb *= max(color, colorToggle).rgb;
 	texture.rgb *= max(texture2D(s_lighting, texCoord2).a, shadowMapToggle);
-
-
-	texture.rgb *= max((max(0.0, dot(normal, vec3(-1,-1,1)*lightDirection)) * lightDiffuse + lightIntensity * lightAmbient), lightToggle);
-	texture += clamp(vec4(texture2D(s_lighting, texCoord2).rgb,1.0), 0.0, 1.0) * lightColorToggle;
+	texture.rgb += clamp(texture2D(s_lighting, texCoord2).rgb, 0.0, 1.0) * lightColorToggle;
 
 	if(fogEnabled)
 	{

--- a/data/shaders/rsm.fs
+++ b/data/shaders/rsm.fs
@@ -30,12 +30,16 @@ void main()
 	if(color.a < 0.1)
 		discard;
 
-	if(shadeType == 1 || shadeType == 2 && lightToggle)
-		color.rgb *= lightIntensity * clamp(dot(normalize(normal), lightDirection),0.0,1.0) * lightDiffuse + lightAmbient;
-
-	if(shadeType == 4 && lightToggle) // only for editor
-		color.rgb *= lightDiffuse;
-
+	if (lightToggle) {
+		// lightIntensity is ignored by the client for whatever reason
+		if (shadeType == 0)
+			color.rgb *= min(lightDiffuse, 1.0 - lightAmbient) * lightDiffuse + lightAmbient;
+		else if (shadeType == 1 || shadeType == 2)
+			color.rgb *= clamp(dot(normalize(normal), lightDirection),0.0,1.0) * min(lightDiffuse, 1.0 - lightAmbient) * lightDiffuse + lightAmbient;
+		else if (shadeType == 4) // only for editor
+			color.rgb *= lightDiffuse;
+	}
+	
 	if(fogEnabled)
 	{
 		float depth = gl_FragCoord.z / gl_FragCoord.w;

--- a/data/shaders/rsm.fs
+++ b/data/shaders/rsm.fs
@@ -35,7 +35,7 @@ void main()
 		if (shadeType == 0)
 			color.rgb *= min(lightDiffuse, 1.0 - lightAmbient) * lightDiffuse + lightAmbient;
 		else if (shadeType == 1 || shadeType == 2)
-			color.rgb *= clamp(dot(normalize(normal), lightDirection),0.0,1.0) * min(lightDiffuse, 1.0 - lightAmbient) * lightDiffuse + lightAmbient;
+			color.rgb *= clamp(dot(normalize(normal), lightDirection),0.0,1.0) * lightDiffuse + lightAmbient;
 		else if (shadeType == 4) // only for editor
 			color.rgb *= lightDiffuse;
 	}


### PR DESCRIPTION
- Adjusted the rotation for the sun light to match the client
- Changed the gnd shader lightmap/tile color/diffuse order.
- Changed the rsm shader to support shadeType 0, it's just not affected by the sun light direction
- Changed the rsm shader formula, removed lightIntensity