### PR TITLE
Fixed RSM2 animations' behavior and using animSpeed to show the correct animation speed.

### DIFF
--- a/browedit/components/RsmRenderer.cpp
+++ b/browedit/components/RsmRenderer.cpp
@@ -228,10 +228,12 @@ void RsmRenderer::renderMesh(Rsm::Mesh* mesh, const glm::mat4& matrix, bool sele
 		mesh->matrixDirty = false;
 
 		if (calcMatrix) {
+			float mult = this->rswModel != nullptr ? this->rswModel->animSpeed : 1.0f;
+			
 			if(time < 0)
-				mesh->calcMatrix1((int)floor(glfwGetTime() * 1000));
+				mesh->calcMatrix1((int)floor(glfwGetTime() * 1000 * mult));
 			else
-				mesh->calcMatrix1((int)floor(time * 1000));
+				mesh->calcMatrix1((int)floor(time * 1000 * mult));
 		}
 
 		if (mesh->model->version >= 0x202) {


### PR DESCRIPTION
- If the tick of the first frame doesn't start at 0, it will now use a default value instead.
- If the current tick goes past the last frame, the animation will stop.
- RSM2 animations now always loop around the model->animLen duration rather than the last frame (RSM1 should also do that).
- The model->animSpeed is now taken into account for the animation shown.