### PR TITLE
More fixes for lub rendering

### DIFF
--- a/browedit/components/LubRenderer.cpp
+++ b/browedit/components/LubRenderer.cpp
@@ -70,7 +70,7 @@ void LubRenderer::render()
 	}
 
 	shader->setUniform(LubShader::Uniforms::billboard_off, (bool)lubEffect->billboard_off);
-	shader->setUniform(LubShader::Uniforms::color, lubEffect->color);
+	shader->setUniform(LubShader::Uniforms::color, glm::vec4(lubEffect->color.r, lubEffect->color.g, lubEffect->color.b, 1.0f));
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	if (texture)

--- a/browedit/components/LubRenderer.cpp
+++ b/browedit/components/LubRenderer.cpp
@@ -69,7 +69,6 @@ void LubRenderer::render()
 		modelMatrix = glm::rotate(modelMatrix, -glm::radians(lubEffect->rotate_angle.x), glm::vec3(1, 0, 0));
 	}
 
-	shader->setUniform(LubShader::Uniforms::modelMatrix, modelMatrix);
 	shader->setUniform(LubShader::Uniforms::billboard_off, (bool)lubEffect->billboard_off);
 	shader->setUniform(LubShader::Uniforms::color, lubEffect->color);
 
@@ -87,9 +86,9 @@ void LubRenderer::render()
 		p.position += (p.dir * lubEffect->speed + p.speed) * elapsedTime;
 		p.life -= elapsedTime;
 		p.speed += lubEffect->speed * lubEffect->gravity * glm::vec3(1, -1, 1) * elapsedTime;
-		
+
 		if (p.start_life > 1) {
-			if (p.life < p.start_life / 2)
+			if (p.life < glm::min(1.0f, p.start_life / 2.0f))
 				p.alpha -= elapsedTime;
 			else
 				p.alpha += elapsedTime;
@@ -97,7 +96,7 @@ void LubRenderer::render()
 			p.alpha = glm::clamp(p.alpha, 0.0f, 1.0f);
 		}
 	}
-	if(particles.size() > 0)
+	if (particles.size() > 0)
 		particles.erase(std::remove_if(particles.begin(), particles.end(), [](const Particle& p) { return p.life < 0; }), particles.end());
 	emitTime -= elapsedTime;
 	if (emitTime < 0 && particles.size() < lubEffect->maxcount)
@@ -108,6 +107,7 @@ void LubRenderer::render()
 			-lubEffect->radius.y + (rand() / (float)RAND_MAX) * (-lubEffect->radius.y + 2 * abs(lubEffect->radius.y) + lubEffect->radius.y),
 			-lubEffect->radius.z + (rand() / (float)RAND_MAX) * (-lubEffect->radius.z + 2 * abs(lubEffect->radius.z) + lubEffect->radius.z)
 		);
+		p.speed = glm::vec3(0);
 		p.dir = glm::vec3(
 			lubEffect->dir1.x + (rand() / (float)RAND_MAX) * (lubEffect->dir2.x - lubEffect->dir1.x),
 			-lubEffect->dir1.y + (rand() / (float)RAND_MAX) * (-lubEffect->dir2.y + lubEffect->dir1.y),
@@ -122,36 +122,45 @@ void LubRenderer::render()
 		emitTime = 1.0f / (lubEffect->rate.x + (rand() / (float)RAND_MAX) * (lubEffect->rate.y - lubEffect->rate.x));
 	}
 
-
+	if (lubEffect->zenable)
+		glEnable(GL_DEPTH_TEST);
+	else
+		glDisable(GL_DEPTH_TEST);
 	glEnable(GL_BLEND);
 	int src = d3dToOpenGlBlend(lubEffect->srcmode);
 	int dst = d3dToOpenGlBlend(lubEffect->destmode);
-	glBlendFuncSeparate(src, dst, GL_ONE, GL_ONE);
+	glBlendFunc(src, dst);
 	glDepthMask(0);
 
 	std::vector<VertexP3T2A1> verts;
 	for (const auto& p : particles)
 	{
 		float alpha = p.alpha;
-		//float alpha = 1.0;
-		verts.push_back(VertexP3T2A1(p.position + glm::vec3(-p.size, -p.size, 0), glm::vec2(0, 0), alpha));
-		verts.push_back(VertexP3T2A1(p.position + glm::vec3(-p.size, p.size, 0), glm::vec2(0, 1), alpha));
-		verts.push_back(VertexP3T2A1(p.position + glm::vec3(p.size, p.size, 0), glm::vec2(1, 1), alpha));
-		verts.push_back(VertexP3T2A1(p.position + glm::vec3(p.size, -p.size, 0), glm::vec2(1, 0), alpha));
+		verts.push_back(VertexP3T2A1(glm::vec3(-p.size, -p.size, 0), glm::vec2(0, 0), alpha));
+		verts.push_back(VertexP3T2A1(glm::vec3(-p.size, p.size, 0), glm::vec2(0, 1), alpha));
+		verts.push_back(VertexP3T2A1(glm::vec3(p.size, p.size, 0), glm::vec2(1, 1), alpha));
+		verts.push_back(VertexP3T2A1(glm::vec3(p.size, -p.size, 0), glm::vec2(1, 0), alpha));
 	}
-
 
 	if (verts.size() > 0)
 	{
-
 		glVertexAttribPointer(0, 3, GL_FLOAT, false, sizeof(VertexP3T2A1), verts[0].data);
 		glVertexAttribPointer(1, 2, GL_FLOAT, false, sizeof(VertexP3T2A1), verts[0].data + 3);
 		glVertexAttribPointer(2, 1, GL_FLOAT, false, sizeof(VertexP3T2A1), verts[0].data + 5);
-		glDrawArrays(GL_QUADS, 0, (int)verts.size());
 	}
+
+	for (int i = 0; i < particles.size(); i++)
+	{
+		Particle p = particles[i];
+		glm::mat4 modelMatrixSub = modelMatrix;
+		modelMatrixSub[3] += glm::vec4(p.position.x, p.position.y, -p.position.z, 0.0f);
+		shader->setUniform(LubShader::Uniforms::modelMatrix, modelMatrixSub);
+		glDrawArrays(GL_QUADS, 4 * i, 4);
+	}
+	
 	glDepthMask(1);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
+	glEnable(GL_DEPTH_TEST);
 }
 
 

--- a/browedit/components/Rsm.cpp
+++ b/browedit/components/Rsm.cpp
@@ -584,18 +584,13 @@ void Rsm::Mesh::calcMatrix1(int time)
 		if (scaleFrames.size() > 0) {
 			int tick = time % glm::max(1, model->animLen);
 			int prevIndex = -1;
-			int nextIndex = -1;
+			int nextIndex = 0;
 
-			while (true) {
-				nextIndex++;
-
-				if (nextIndex == scaleFrames.size() || tick < scaleFrames[nextIndex].time)
-					break;
-
-				prevIndex++;
+			for (; nextIndex < scaleFrames.size() && tick >= scaleFrames[nextIndex].time; nextIndex++) {
 			}
 
-			float prevTick = (float)(prevIndex < 0 ? 0 : scaleFrames[prevIndex].time); //TODO: this part is repeated for rot,scale,pos... dedupe code
+			prevIndex = nextIndex - 1;
+			float prevTick = (float)(prevIndex < 0 ? 0 : scaleFrames[prevIndex].time);
 			float nextTick = (float)(nextIndex == scaleFrames.size() ? model->animLen : scaleFrames[nextIndex].time);
 			glm::vec3 prev = prevIndex < 0 ? glm::vec3(1) : scaleFrames[prevIndex].scale;
 			glm::vec3 next = nextIndex == scaleFrames.size() ? scaleFrames[nextIndex - 1].scale : scaleFrames[nextIndex].scale;
@@ -608,22 +603,17 @@ void Rsm::Mesh::calcMatrix1(int time)
 		{
 			int tick = time % glm::max(1, model->animLen);
 			int prevIndex = -1;
-			int nextIndex = -1;
-
-			while (true) {
-				nextIndex++;
-
-				if (nextIndex == rotFrames.size() || tick < rotFrames[nextIndex].time)
-					break;
-
-				prevIndex++;
+			int nextIndex = 0;
+			
+			for (; nextIndex < rotFrames.size() && tick >= rotFrames[nextIndex].time; nextIndex++) {
 			}
-
+			
+			prevIndex = nextIndex - 1;
 			float prevTick = (float)(prevIndex < 0 ? 0 : rotFrames[prevIndex].time);
 			float nextTick = (float)(nextIndex == rotFrames.size() ? model->animLen : rotFrames[nextIndex].time);
-			glm::quat prev = prevIndex < 0 ? glm::quat() : rotFrames[prevIndex].quaternion;
+			glm::quat prev = prevIndex < 0 ? glm::quat(1, 0, 0, 0) : rotFrames[prevIndex].quaternion;
 			glm::quat next = nextIndex == rotFrames.size() ? rotFrames[nextIndex - 1].quaternion : rotFrames[nextIndex].quaternion;
-
+			
 			float mult = (tick - prevTick) / (nextTick - prevTick);
 			glm::quat quat = glm::slerp(prev, next, mult);
 			matrix1 = glm::toMat4(quat) * matrix1;
@@ -644,17 +634,12 @@ void Rsm::Mesh::calcMatrix1(int time)
 		if (posFrames.size() > 0) {
 			int tick = time % glm::max(1, model->animLen);
 			int prevIndex = -1;
-			int nextIndex = -1;
+			int nextIndex = 0;
 
-			while (true) {
-				nextIndex++;
-
-				if (nextIndex == posFrames.size() || tick < posFrames[nextIndex].time)
-					break;
-
-				prevIndex++;
+			for (; nextIndex < posFrames.size() && tick >= posFrames[nextIndex].time; nextIndex++) {
 			}
 
+			prevIndex = nextIndex - 1;
 			float prevTick = (float)(prevIndex < 0 ? 0 : posFrames[prevIndex].time);
 			float nextTick = (float)(nextIndex == posFrames.size() ? model->animLen : posFrames[nextIndex].time);
 			glm::vec3 prev = prevIndex < 0 ? pos_ : posFrames[prevIndex].position;

--- a/browedit/components/RsmRenderer.cpp
+++ b/browedit/components/RsmRenderer.cpp
@@ -224,7 +224,7 @@ void RsmRenderer::renderMesh(Rsm::Mesh* mesh, const glm::mat4& matrix, bool sele
 			textures.push_back(util::ResourceManager<gl::Texture>::load("data\\texture\\" + textureFilename));
 	}
 
-	if (mesh && (!mesh->rotFrames.empty() || mesh->matrixDirty || !mesh->scaleFrames.empty() || !mesh->posFrames.empty()))
+	if (mesh && (!mesh->rotFrames.empty() || mesh->matrixDirty || mesh->model->version >= 0x202))
 	{
 		mesh->matrixDirty = false;
 

--- a/browedit/components/Rsw.Effect.cpp
+++ b/browedit/components/Rsw.Effect.cpp
@@ -118,6 +118,7 @@ void LubEffect::load(const json& data)
 	srcmode = data["srcmode"][0];
 	destmode = data["destmode"][0];
 	maxcount = data["maxcount"][0];
+	zenable = data["zenable"][0];
 	
 	if (data.find("billboard_off") != data.end())
 		billboard_off = data["billboard_off"][0];

--- a/data/shaders/gnd.fs
+++ b/data/shaders/gnd.fs
@@ -36,7 +36,8 @@ void main()
 	if(texture.a < 0.1)
 		discard;
 	
-	texture.rgb *= max((max(0.0, dot(normal, vec3(1,-1,1)*lightDirection)) * lightDiffuse + lightIntensity * lightAmbient), lightToggle);
+	float NL = clamp(dot(normalize(normal), vec3(1,-1,1)*lightDirection),0.0,1.0);
+	texture.rgb *= max((NL * min(lightDiffuse, 1.0 - lightAmbient) * lightDiffuse + lightAmbient), lightToggle);
 	texture.rgb *= max(color, colorToggle).rgb;
 	texture.rgb *= max(texture2D(s_lighting, texCoord2).a, shadowMapToggle);
 	texture.rgb += clamp(texture2D(s_lighting, texCoord2).rgb, 0.0, 1.0) * lightColorToggle;

--- a/data/shaders/lub.fs
+++ b/data/shaders/lub.fs
@@ -12,8 +12,6 @@ void main()
 {
 	vec4 outColor = texture2D(s_texture, texCoord);
 	outColor *= color;
-	outColor.a *= alpha;
-	//if(outColor.a < 0.1)
-	//	discard;
+	outColor.a = alpha;
 	fragColor = outColor;
 }

--- a/data/shaders/lub.fs
+++ b/data/shaders/lub.fs
@@ -12,6 +12,6 @@ void main()
 {
 	vec4 outColor = texture2D(s_texture, texCoord);
 	outColor *= color;
-	outColor.a = alpha;
+	outColor.a *= alpha;
 	fragColor = outColor;
 }

--- a/data/shaders/rsm.fs
+++ b/data/shaders/rsm.fs
@@ -31,11 +31,12 @@ void main()
 		discard;
 
 	if (lightToggle) {
-		// lightIntensity is ignored by the client for whatever reason
 		if (shadeType == 0)
 			color.rgb *= min(lightDiffuse, 1.0 - lightAmbient) * lightDiffuse + lightAmbient;
-		else if (shadeType == 1 || shadeType == 2)
-			color.rgb *= clamp(dot(normalize(normal), lightDirection),0.0,1.0) * lightDiffuse + lightAmbient;
+		else if (shadeType == 1 || shadeType == 2) {
+			float NL = clamp(dot(normalize(normal), lightDirection),0.0,1.0);
+			color.rgb *= NL * min(lightDiffuse, 1.0 - lightAmbient) * lightDiffuse + lightAmbient;
+		}
 		else if (shadeType == 4) // only for editor
 			color.rgb *= lightDiffuse;
 	}


### PR DESCRIPTION
- Ignores the alpha value for the lub effect color property (client always reads it as 255).
- Added the billboard_off property when saving the lub effect file.
- Parses the zenable property and handles its effect when rendering.
- Fixed the alpha value increase that made the lub effects not appear, which I introduced previously (my bad).
- billboards now apply for each particle individually rather than the entire effect.
- The lub index in the file is now taken into account rather than reading them in a linear fashion.
- Fixed an issue with lub effect texture paths not being recognized by the client if they have spaces in them.
- Fixed a light issue with the rsm/gnd shader.
- Small fix for rsm animation.