### PR TITLE
Added support for the gnd water

### DIFF
--- a/BrowEdit3.vcxproj
+++ b/BrowEdit3.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="browedit\actions\TileNewAction.cpp" />
     <ClCompile Include="browedit\actions\TilePropertyChangeAction.cpp" />
     <ClCompile Include="browedit\actions\TileSelectAction.cpp" />
+    <ClCompile Include="browedit\actions\WaterSplitChangeAction.cpp" />
     <ClCompile Include="browedit\BrowEdit.cpp" />
     <ClCompile Include="browedit\BrowEdit.glfw.cpp" />
     <ClCompile Include="browedit\BrowEdit.imgui.cpp" />
@@ -148,6 +149,7 @@
     <ClInclude Include="browedit\actions\TileNewAction.h" />
     <ClInclude Include="browedit\actions\TilePropertyChangeAction.h" />
     <ClInclude Include="browedit\actions\TileSelectAction.h" />
+    <ClInclude Include="browedit\actions\WaterSplitChangeAction.h" />
     <ClInclude Include="browedit\BrowEdit.h" />
     <ClInclude Include="browedit\components\BillboardRenderer.h" />
     <ClInclude Include="browedit\components\Collider.h" />

--- a/BrowEdit3.vcxproj
+++ b/BrowEdit3.vcxproj
@@ -16,6 +16,7 @@
     <ClCompile Include="browedit\actions\DeleteObjectAction.cpp" />
     <ClCompile Include="browedit\actions\GatTileChangeAction.cpp" />
     <ClCompile Include="browedit\actions\GndTextureActions.cpp" />
+    <ClCompile Include="browedit\actions\GndVersionChangeAction.cpp" />
     <ClCompile Include="browedit\actions\GroupAction.cpp" />
     <ClCompile Include="browedit\actions\ModelChangeAction.cpp" />
     <ClCompile Include="browedit\actions\NewObjectAction.cpp" />
@@ -137,6 +138,7 @@
     <ClInclude Include="browedit\actions\DeleteObjectAction.h" />
     <ClInclude Include="browedit\actions\GatTileChangeAction.h" />
     <ClInclude Include="browedit\actions\GndTextureActions.h" />
+    <ClInclude Include="browedit\actions\GndVersionChangeAction.h" />
     <ClInclude Include="browedit\actions\GroupAction.h" />
     <ClInclude Include="browedit\actions\ModelChangeAction.h" />
     <ClInclude Include="browedit\actions\NewObjectAction.h" />

--- a/BrowEdit3.vcxproj.filters
+++ b/BrowEdit3.vcxproj.filters
@@ -412,6 +412,9 @@
     <ClCompile Include="lib\tinygltf\tiny_gltf.cc">
       <Filter>lib\tinygltf</Filter>
     </ClCompile>
+    <ClCompile Include="browedit\actions\WaterSplitChangeAction.cpp">
+      <Filter>browedit\actions</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\imgui\imgui.h">
@@ -710,6 +713,9 @@
     </ClInclude>
     <ClInclude Include="lib\tinygltf\tiny_gltf.h">
       <Filter>lib\tinygltf</Filter>
+    </ClInclude>
+    <ClInclude Include="browedit\actions\WaterSplitChangeAction.h">
+      <Filter>browedit\actions</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/BrowEdit3.vcxproj.filters
+++ b/BrowEdit3.vcxproj.filters
@@ -415,6 +415,9 @@
     <ClCompile Include="browedit\actions\WaterSplitChangeAction.cpp">
       <Filter>browedit\actions</Filter>
     </ClCompile>
+    <ClCompile Include="browedit\actions\GndVersionChangeAction.cpp">
+      <Filter>browedit\actions</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\imgui\imgui.h">
@@ -715,6 +718,9 @@
       <Filter>lib\tinygltf</Filter>
     </ClInclude>
     <ClInclude Include="browedit\actions\WaterSplitChangeAction.h">
+      <Filter>browedit\actions</Filter>
+    </ClInclude>
+    <ClInclude Include="browedit\actions\GndVersionChangeAction.h">
       <Filter>browedit\actions</Filter>
     </ClInclude>
   </ItemGroup>

--- a/browedit/BrowEdit.cpp
+++ b/browedit/BrowEdit.cpp
@@ -689,7 +689,7 @@ void BrowEdit::saveMap(Map* map)
 	}
 
 	map->rootNode->getComponent<Rsw>()->save(rswName, this);
-	map->rootNode->getComponent<Gnd>()->save(gndName);
+	map->rootNode->getComponent<Gnd>()->save(gndName, map->rootNode->getComponent<Rsw>());
 	map->rootNode->getComponent<Gat>()->save(gatName);
 
 	map->changed = false;
@@ -751,7 +751,7 @@ void BrowEdit::saveAsMap(Map* map)
 	map->rootNode->getComponent<Rsw>()->gatFile = mapName + ".gat";
 	map->rootNode->getComponent<Rsw>()->gndFile = mapName + ".gnd";
 	map->rootNode->getComponent<Rsw>()->save(rswName, this);
-	map->rootNode->getComponent<Gnd>()->save(gndName);
+	map->rootNode->getComponent<Gnd>()->save(gndName, map->rootNode->getComponent<Rsw>());
 	map->rootNode->getComponent<Gat>()->save(gatName);
 }
 

--- a/browedit/MapView.cpp
+++ b/browedit/MapView.cpp
@@ -349,8 +349,15 @@ void MapView::render(BrowEdit* browEdit)
 
 	if (ortho)
 		nodeRenderContext.projectionMatrix = glm::ortho(-cameraDistance/2*ratio, cameraDistance/2 * ratio, -cameraDistance/2, cameraDistance/2, -5000.0f, 5000.0f);
-	else
-		nodeRenderContext.projectionMatrix = glm::perspective(glm::radians(browEdit->config.fov), ratio, 0.1f, 5000.0f);
+	else {
+		float nearPlane = 0.1f;
+
+		if (cameraDistance > 500)
+			nearPlane = 10.0f;
+		else if (cameraDistance > 25)
+			nearPlane = 1.0f;
+		nodeRenderContext.projectionMatrix = glm::perspective(glm::radians(browEdit->config.fov), ratio, nearPlane, 5000.0f);
+	}
 	if (cinematicPlay && rsw->cinematicTracks.size() > 0)
 	{
 		auto beforePos = (Rsw::KeyFrameData<std::pair<glm::vec3, glm::vec3>>*)rsw->cinematicTracks[0].getBeforeFrame(timeSelected);

--- a/browedit/actions/CubeHeightChangeAction.cpp
+++ b/browedit/actions/CubeHeightChangeAction.cpp
@@ -45,13 +45,8 @@ void CubeHeightChangeAction<T, TC>::perform(Map* map, BrowEdit* browEdit)
 		if (gndRenderer) {
 			for (auto t : selection) {
 				gndRenderer->setChunkDirty(t.x, t.y);
-				
-				// For walls on the chunk's edge
-				if (gnd->inMap(glm::ivec2(t.x, t.y - 1)))
-					gndRenderer->setChunkDirty(t.x, t.y - 1);
-
-				if (gnd->inMap(glm::ivec2(t.x - 1, t.y)))
-					gndRenderer->setChunkDirty(t.x - 1, t.y);
+				gndRenderer->setChunkDirty(t.x - 1, t.y);
+				gndRenderer->setChunkDirty(t.x, t.y - 1);
 			}
 		}
 	}
@@ -80,13 +75,8 @@ void CubeHeightChangeAction<T, TC>::undo(Map* map, BrowEdit* browEdit)
 		if (gndRenderer) {
 			for (auto t : selection) {
 				gndRenderer->setChunkDirty(t.x, t.y);
-
-				// For walls on the chunk's edge
-				if (gnd->inMap(glm::ivec2(t.x, t.y - 1)))
-					gndRenderer->setChunkDirty(t.x, t.y - 1);
-
-				if (gnd->inMap(glm::ivec2(t.x - 1, t.y)))
-					gndRenderer->setChunkDirty(t.x - 1, t.y);
+				gndRenderer->setChunkDirty(t.x - 1, t.y);
+				gndRenderer->setChunkDirty(t.x, t.y - 1);
 			}
 		}
 	}

--- a/browedit/actions/CubeTileChangeAction.cpp
+++ b/browedit/actions/CubeTileChangeAction.cpp
@@ -51,6 +51,9 @@ void CubeTileChangeAction::perform(Map* map, BrowEdit* browEdit)
 	{
 		for (auto t : selection) {
 			gndRenderer->setChunkDirty(t.x, t.y);
+			gndRenderer->setChunkDirty(t.x - 1, t.y);
+			gndRenderer->setChunkDirty(t.x, t.y - 1);
+			gndRenderer->setChunkDirty(t.x - 1, t.y - 1);
 		}
 		if (this->shadowDirty)
 			gndRenderer->gndShadowDirty = true;
@@ -70,6 +73,9 @@ void CubeTileChangeAction::undo(Map* map, BrowEdit* browEdit)
 	{
 		for (auto t : selection) {
 			gndRenderer->setChunkDirty(t.x, t.y);
+			gndRenderer->setChunkDirty(t.x - 1, t.y);
+			gndRenderer->setChunkDirty(t.x, t.y - 1);
+			gndRenderer->setChunkDirty(t.x - 1, t.y - 1);
 		}
 		if (this->shadowDirty)
 			gndRenderer->gndShadowDirty = true;

--- a/browedit/actions/GndVersionChangeAction.cpp
+++ b/browedit/actions/GndVersionChangeAction.cpp
@@ -1,0 +1,31 @@
+#include "GndVersionChangeAction.h"
+#include <browedit/Map.h>
+#include <browedit/Node.h>
+#include <browedit/components/Gnd.h>
+
+GndVersionChangeAction::GndVersionChangeAction(int oldValue, int newValue)
+{
+	this->oldValue = oldValue;
+	this->newValue = newValue;
+}
+
+void GndVersionChangeAction::perform(Map* map, BrowEdit* browEdit)
+{
+	auto gnd = map->rootNode->getComponent<Gnd>();
+	if (gnd) {
+		gnd->version = newValue;
+	}
+}
+
+void GndVersionChangeAction::undo(Map* map, BrowEdit* browEdit)
+{
+	auto gnd = map->rootNode->getComponent<Gnd>();
+	if (gnd) {
+		gnd->version = oldValue;
+	}
+}
+
+std::string GndVersionChangeAction::str()
+{
+	return "GND version set to " + std::to_string(this->newValue);
+}

--- a/browedit/actions/GndVersionChangeAction.h
+++ b/browedit/actions/GndVersionChangeAction.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Action.h"
+#include <browedit/components/Gnd.h>
+#include <vector>
+
+class GndVersionChangeAction : public Action
+{
+	int oldValue;
+	int newValue;
+public:
+	GndVersionChangeAction(int oldValue, int newValue);
+
+	virtual void perform(Map* map, BrowEdit* browEdit);
+	virtual void undo(Map* map, BrowEdit* browEdit);
+	virtual std::string str();
+};

--- a/browedit/actions/TilePropertyChangeAction.h
+++ b/browedit/actions/TilePropertyChangeAction.h
@@ -39,12 +39,9 @@ public:
 		if (gndRenderer)
 		{
 			gndRenderer->setChunkDirty(position.x, position.y);
-
-			if (gndRenderer->gnd->inMap(glm::ivec2(position.x - 1, position.y)))
-				gndRenderer->setChunkDirty(position.x - 1, position.y);
-
-			if (gndRenderer->gnd->inMap(glm::ivec2(position.x, position.y - 1)))
-				gndRenderer->setChunkDirty(position.x, position.y - 1);
+			gndRenderer->setChunkDirty(position.x - 1, position.y);
+			gndRenderer->setChunkDirty(position.x, position.y - 1);
+			gndRenderer->setChunkDirty(position.x - 1, position.y - 1);
 		}
 	}
 	virtual void undo(Map* map, BrowEdit* browEdit)
@@ -54,12 +51,9 @@ public:
 		if (gndRenderer)
 		{
 			gndRenderer->setChunkDirty(position.x, position.y);
-
-			if (gndRenderer->gnd->inMap(glm::ivec2(position.x - 1, position.y)))
-				gndRenderer->setChunkDirty(position.x - 1, position.y);
-
-			if (gndRenderer->gnd->inMap(glm::ivec2(position.x, position.y - 1)))
-				gndRenderer->setChunkDirty(position.x, position.y - 1);
+			gndRenderer->setChunkDirty(position.x - 1, position.y);
+			gndRenderer->setChunkDirty(position.x, position.y - 1);
+			gndRenderer->setChunkDirty(position.x - 1, position.y - 1);
 		}
 	}
 	virtual std::string str()

--- a/browedit/actions/WaterSplitChangeAction.cpp
+++ b/browedit/actions/WaterSplitChangeAction.cpp
@@ -1,0 +1,58 @@
+#include "WaterSplitChangeAction.h"
+#include <browedit/Map.h>
+#include <browedit/Node.h>
+#include <browedit/components/WaterRenderer.h>
+#include <browedit/components/Rsw.h>
+
+WaterSplitChangeAction::WaterSplitChangeAction(Rsw::WaterData& waterData, int oldSplitWidth, int oldSplitHeight)
+{
+	this->oldSplitWidth = oldSplitWidth;
+	this->oldSplitHeight = oldSplitHeight;
+	this->newSplitWidth = waterData.splitWidth;
+	this->newSplitHeight = waterData.splitHeight;
+
+	oldValues = waterData.zones;
+
+	newValues.clear();
+	newValues.resize(newSplitWidth, std::vector<Rsw::Water>(newSplitHeight));
+
+	for (int y = 0; y < newSplitHeight; y++) {
+		for (int x = 0; x < newSplitWidth; x++) {
+			if (x < waterData.splitWidth && y < waterData.splitHeight)
+				newValues[x][y] = oldValues[x][y];
+		}
+	}
+}
+
+void WaterSplitChangeAction::perform(Map* map, BrowEdit* browEdit)
+{
+	auto rsw = map->rootNode->getComponent<Rsw>();
+	if (rsw) {
+		rsw->water.zones = newValues;
+		rsw->water.splitHeight = newSplitHeight;
+		rsw->water.splitWidth = newSplitWidth;
+	}
+	auto waterRenderer = map->rootNode->getComponent<WaterRenderer>();
+	if (waterRenderer) {
+		waterRenderer->setDirty();
+	}
+}
+
+void WaterSplitChangeAction::undo(Map* map, BrowEdit* browEdit)
+{
+	auto rsw = map->rootNode->getComponent<Rsw>();
+	if (rsw) {
+		rsw->water.zones = oldValues;
+		rsw->water.splitHeight = oldSplitHeight;
+		rsw->water.splitWidth = oldSplitWidth;
+	}
+	auto waterRenderer = map->rootNode->getComponent<WaterRenderer>();
+	if (waterRenderer) {
+		waterRenderer->setDirty();
+	}
+}
+
+std::string WaterSplitChangeAction::str()
+{
+	return "Water split changed";
+}

--- a/browedit/actions/WaterSplitChangeAction.h
+++ b/browedit/actions/WaterSplitChangeAction.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Action.h"
+#include <browedit/components/Rsw.h>
+#include <vector>
+
+class WaterSplitChangeAction : public Action
+{
+	std::vector< std::vector<Rsw::Water>> oldValues;
+	std::vector< std::vector<Rsw::Water>> newValues;
+	int oldSplitWidth;
+	int oldSplitHeight;
+	int newSplitWidth;
+	int newSplitHeight;
+public:
+	WaterSplitChangeAction(Rsw::WaterData& waterData, int oldSplitWidth, int oldSplitHeight);
+
+	virtual void perform(Map* map, BrowEdit* browEdit);
+	virtual void undo(Map* map, BrowEdit* browEdit);
+	virtual std::string str();
+};

--- a/browedit/components/GatRenderer.cpp
+++ b/browedit/components/GatRenderer.cpp
@@ -129,7 +129,13 @@ void GatRenderer::Chunk::rebuild()
 		for (int y = this->y; y < glm::min(this->y + CHUNKSIZE, (int)gat->cubes[x].size()); y++)
 		{
 			Gat::Cube* cube = gat->cubes[x][y];
-			glm::vec2 t1(.25f * (cube->gatType%4), .25f * (cube->gatType/4));
+			int gatType = cube->gatType;
+
+			if (gatType < 0) {
+				gatType &= ~0x80000000;
+			}
+
+			glm::vec2 t1(.25f * (gatType%4), .25f * (gatType/4));
 			glm::vec2 t2 = t1 + glm::vec2(.25f);
 
 			VertexP3T2N3 v1(glm::vec3(5 * x,	-cube->h3, 5 * gat->height - 5 * y + 5),	glm::vec2(t1.x, t1.y), cube->normal);
@@ -154,7 +160,9 @@ void GatRenderer::setChunkDirty(int x, int y)
 	if (this->allDirty)
 		return;
 
-	chunks[y / CHUNKSIZE][x / CHUNKSIZE]->dirty = true;
+	if (y >= 0 && y / CHUNKSIZE < chunks.size() &&
+		x >= 0 && x / CHUNKSIZE < chunks[y / CHUNKSIZE].size())
+		chunks[y / CHUNKSIZE][x / CHUNKSIZE]->dirty = true;
 }
 
 void GatRenderer::setChunksDirty()

--- a/browedit/components/Gnd.h
+++ b/browedit/components/Gnd.h
@@ -11,6 +11,7 @@
 
 class Map;
 class BrowEdit;
+class Rsw;
 
 namespace gl {
 	class Texture;
@@ -19,10 +20,10 @@ namespace gl {
 class Gnd : public Component, public ImguiProps
 {
 public:
-	Gnd(const std::string& fileName);
+	Gnd(const std::string& fileName, Rsw* rsw);
 	Gnd(int width, int height);
 	~Gnd();
-	void save(const std::string &fileName);
+	void save(const std::string &fileName, Rsw* rsw);
 	glm::vec3 rayCast(const math::Ray& ray, bool emptyTiles = false, int xMin = 0, int yMin = 0, int xMax = -1, int yMax = -1, float offset = 0.0f);
 	void makeLightmapsUnique();
 	void makeLightmapsClear();

--- a/browedit/components/GndRenderer.cpp
+++ b/browedit/components/GndRenderer.cpp
@@ -264,15 +264,24 @@ void GndRenderer::Chunk::rebuild()
 				}
 
 				glm::vec4 c1(1.0);
-				if(y < gnd->height-1 && gnd->cubes[x][y + 1]->tileUp != -1)
-					c1 = glm::vec4(gnd->tiles[gnd->cubes[x][y + 1]->tileUp]->color) / 255.0f;
+				if(y < gnd->height-1)
+					if (gnd->cubes[x][y + 1]->tileUp == -1)
+						c1 = glm::vec4(0);
+					else
+						c1 = glm::vec4(gnd->tiles[gnd->cubes[x][y + 1]->tileUp]->color) / 255.0f;
 				glm::vec4 c2(1.0f);
-				if (x < gnd->width - 1 && y < gnd->height - 1 && gnd->cubes[x + 1][y + 1]->tileUp != -1)
-					c2 = glm::vec4(gnd->tiles[gnd->cubes[x + 1][y + 1]->tileUp]->color) / 255.0f;
+				if (x < gnd->width - 1 && y < gnd->height - 1)
+					if (gnd->cubes[x + 1][y + 1]->tileUp == -1)
+						c2 = glm::vec4(0);
+					else
+						c2 = glm::vec4(gnd->tiles[gnd->cubes[x + 1][y + 1]->tileUp]->color) / 255.0f;
 				glm::vec4 c3 = glm::vec4(tile->color) / 255.0f;
 				glm::vec4 c4(1.0f);
-				if (x < gnd->width - 1 && gnd->cubes[x + 1][y]->tileUp != -1)
-					c4 = glm::vec4(gnd->tiles[gnd->cubes[x+1][y]->tileUp]->color) / 255.0f;
+				if (x < gnd->width - 1)
+					if (gnd->cubes[x + 1][y]->tileUp == -1)
+						c4 = glm::vec4(0);
+					else
+						c4 = glm::vec4(gnd->tiles[gnd->cubes[x+1][y]->tileUp]->color) / 255.0f;
 
 				VertexP3T2T2C4N3 v1(glm::vec3(10 * x, -cube->h3, 10 * gnd->height - 10 * y),			tile->v3, glm::vec2(lm1.x, lm2.y), c1,		cube->normals[2]);
 				VertexP3T2T2C4N3 v2(glm::vec3(10 * x + 10, -cube->h4, 10 * gnd->height - 10 * y),		tile->v4, glm::vec2(lm2.x, lm2.y), c2,		cube->normals[3]);
@@ -360,7 +369,9 @@ void GndRenderer::Chunk::rebuild()
 
 void GndRenderer::setChunkDirty(int x, int y)
 {
-	chunks[y / CHUNKSIZE][x / CHUNKSIZE]->dirty = true;
+	if (y >= 0 && y / CHUNKSIZE < chunks.size() &&
+		x >= 0 && x / CHUNKSIZE < chunks[y / CHUNKSIZE].size())
+		chunks[y / CHUNKSIZE][x / CHUNKSIZE]->dirty = true;
 }
 
 void GndRenderer::setChunksDirty()

--- a/browedit/components/Rsw.Model.cpp
+++ b/browedit/components/Rsw.Model.cpp
@@ -27,7 +27,7 @@ void RswModel::load(std::istream* is, int version, unsigned char buildNumber, bo
 		is->read(reinterpret_cast<char*>(&animSpeed), sizeof(float));
 		is->read(reinterpret_cast<char*>(&blockType), sizeof(int));
 	}
-	if (version >= 0x0206 && buildNumber > 161)
+	if (version >= 0x0206 && buildNumber >= 186)
 	{
 		unsigned char c = is->get(); // unknown, 0?
 	}
@@ -64,7 +64,7 @@ void RswModel::loadExtra(nlohmann::json data)
 
 
 
-void RswModel::save(std::ofstream& file, int version)
+void RswModel::save(std::ofstream& file, int version, int buildNumber)
 {
 	auto rswObject = node->getComponent<RswObject>();
 	if (version >= 0x103)
@@ -73,6 +73,10 @@ void RswModel::save(std::ofstream& file, int version)
 		file.write(reinterpret_cast<char*>(&animType), sizeof(int));
 		file.write(reinterpret_cast<char*>(&animSpeed), sizeof(float));
 		file.write(reinterpret_cast<char*>(&blockType), sizeof(int));
+
+		if (version >= 0x206 && buildNumber >= 186) {
+			file.put(0); // ??
+		}
 	}
 	util::FileIO::writeString(file, util::utf8_to_iso_8859_1(fileName), 80);
 	util::FileIO::writeString(file, util::utf8_to_iso_8859_1(objectName), 80); //unknown

--- a/browedit/components/Rsw.Object.cpp
+++ b/browedit/components/Rsw.Object.cpp
@@ -66,7 +66,7 @@ void RswObject::load(std::istream* is, int version, unsigned char buildNumber, b
 
 
 
-void RswObject::save(std::ofstream& file, int version)
+void RswObject::save(std::ofstream& file, Rsw* rsw)
 {
 	RswModel* rswModel = nullptr;
 	RswEffect* rswEffect = nullptr;
@@ -82,10 +82,10 @@ void RswObject::save(std::ofstream& file, int version)
 	if (rswEffect = node->getComponent<RswEffect>())
 		type = 4;
 	file.write(reinterpret_cast<char*>(&type), sizeof(int));
-	if (rswModel)		rswModel->save(file, version); //meh don't like this if...maybe make this an interface savable
+	if (rswModel)		rswModel->save(file, rsw->version, rsw->buildNumber); //meh don't like this if...maybe make this an interface savable
 	if (rswEffect)		rswEffect->save(file);
 	if (rswLight)		rswLight->save(file);
-	if (rswSound)		rswSound->save(file, version);
+	if (rswSound)		rswSound->save(file, rsw->version);
 }
 
 

--- a/browedit/components/Rsw.cpp
+++ b/browedit/components/Rsw.cpp
@@ -1377,18 +1377,12 @@ void Rsw::WaterData::resize(int width, int height) {
 	for (int y = 0; y < zones.size(); y++) {
 		if (zones[y].size() < height) {
 			for (int x = (int)zones[y].size(); x < height; x++) {
-				zones[y].push_back(Rsw::Water());
+				zones[y].push_back(zones[y][zones[y].size() - 1]);
 			}
 		}
 	}
 
 	for (int y = (int)zones.size(); y < width; y++) {
-		zones.push_back(std::vector<Rsw::Water>(splitHeight));
-
-		if (zones[y].size() < height) {
-			for (int x = (int)zones[y].size(); x < height; x++) {
-				zones[y].push_back(Rsw::Water());
-			}
-		}
+		zones.push_back(zones[zones.size() - 1]);
 	}
 }

--- a/browedit/components/Rsw.cpp
+++ b/browedit/components/Rsw.cpp
@@ -25,6 +25,8 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <browedit/Node.h>
 #include <imGuIZMOquat.h>
+#include <browedit/actions/GroupAction.h>
+#include <browedit/actions/WaterSplitChangeAction.h>
 
 
 Rsw::Rsw()
@@ -216,16 +218,15 @@ void Rsw::load(const std::string& fileName, Map* map, BrowEdit* browEdit, bool l
 	version = util::swapShort(version);
 	std::cout << std::hex<<"RSW: Version 0x" << version << std::endl <<std::dec;
 
-	if (version >= 0x0202)
-	{
-		buildNumber = file->get();
-		std::cout << "Build number " << (int)buildNumber << std::endl;
-	}
 	if (version >= 0x0205)
 	{
-		int u;
-		file->read(reinterpret_cast<char*>(&u), sizeof(int));
-		std::cout << "205 unknown value: " << u << std::endl;
+		file->read(reinterpret_cast<char*>(&buildNumber), sizeof(int));
+		std::cout << "Build number " << buildNumber << std::endl;
+	}
+	if (version >= 0x0202)
+	{
+		unsigned char u = file->get();
+		std::cout << "202 unknown value: " << (int)u << std::endl;
 	}
 
 	iniFile = util::FileIO::readString(file, 40);
@@ -236,25 +237,30 @@ void Rsw::load(const std::string& fileName, Map* map, BrowEdit* browEdit, bool l
 		gatFile = gndFile; //TODO: convert
 
 	iniFile = util::FileIO::readString(file, 40); // ehh...read inifile twice?
-
-	//version 0x0206
-	if (version < 0x0206)
+	
+	//version 0x206
+	if (version < 0x206)
 	{
+		water.splitWidth = 1;
+		water.splitHeight = 1;
+		water.zones.clear();
+		water.zones.resize(water.splitWidth, std::vector<Rsw::Water>(water.splitHeight));
+
 		//TODO: default values
 		if (version >= 0x103)
-			file->read(reinterpret_cast<char*>(&water.height), sizeof(float));
+			file->read(reinterpret_cast<char*>(&water.zones[0][0].height), sizeof(float));
 		if (version >= 0x108)
 		{
-			file->read(reinterpret_cast<char*>(&water.type), sizeof(int));
-			file->read(reinterpret_cast<char*>(&water.amplitude), sizeof(float));
-			file->read(reinterpret_cast<char*>(&water.waveSpeed), sizeof(float));
-			file->read(reinterpret_cast<char*>(&water.wavePitch), sizeof(float));
+			file->read(reinterpret_cast<char*>(&water.zones[0][0].type), sizeof(int));
+			file->read(reinterpret_cast<char*>(&water.zones[0][0].amplitude), sizeof(float));
+			file->read(reinterpret_cast<char*>(&water.zones[0][0].waveSpeed), sizeof(float));
+			file->read(reinterpret_cast<char*>(&water.zones[0][0].wavePitch), sizeof(float));
 		}
 		if (version >= 0x109)
-			file->read(reinterpret_cast<char*>(&water.textureAnimSpeed), sizeof(int));
+			file->read(reinterpret_cast<char*>(&water.zones[0][0].textureAnimSpeed), sizeof(int));
 		else
 		{
-			water.textureAnimSpeed = 100;
+			water.zones[0][0].textureAnimSpeed = 100;
 	//		throw "todo";
 		}
 	}
@@ -264,7 +270,7 @@ void Rsw::load(const std::string& fileName, Map* map, BrowEdit* browEdit, bool l
 		std::string path = fileName;
 		if (path.find("\\") != std::string::npos)
 			path = path.substr(0, path.rfind("\\")+1);
-		node->addComponent(new Gnd(path + gndFile));
+		node->addComponent(new Gnd(path + gndFile, this));
 		node->addComponent(new GndRenderer());
 		node->addComponent(new WaterRenderer());
 		//TODO: read GND & GAT here
@@ -454,8 +460,10 @@ void Rsw::save(const std::string& fileName, BrowEdit* browEdit)
 	short versionFlipped = util::swapShort(version);
 	file.write(reinterpret_cast<char*>(&versionFlipped), sizeof(short));
 
-	if (version == 0x0202)
-		file.put(0); // ???
+	if (version >= 0x0205)
+		file.write(reinterpret_cast<char*>(&buildNumber), sizeof(int));
+	if (version >= 0x0202)
+		file.put(1); // ???
 	util::FileIO::writeString(file, iniFile, 40);
 
 	util::FileIO::writeString(file, gndFile, 40);
@@ -466,21 +474,23 @@ void Rsw::save(const std::string& fileName, BrowEdit* browEdit)
 	}
 	util::FileIO::writeString(file, iniFile, 40);
 
-	if (version >= 0x103)
-		file.write(reinterpret_cast<char*>(&water.height), sizeof(float));
-	if (version >= 0x108)
-	{
-		file.write(reinterpret_cast<char*>(&water.type), sizeof(int));
-		file.write(reinterpret_cast<char*>(&water.amplitude), sizeof(float));
-		file.write(reinterpret_cast<char*>(&water.waveSpeed), sizeof(float));
-		file.write(reinterpret_cast<char*>(&water.wavePitch), sizeof(float));
-	}
-	if (version >= 0x109)
-		file.write(reinterpret_cast<char*>(&water.textureAnimSpeed), sizeof(int));
-	else
-	{
-		water.textureAnimSpeed = 100;
-		throw "todo";
+	if (version < 0x206) {
+		if (version >= 0x103)
+			file.write(reinterpret_cast<char*>(&water.zones[0][0].height), sizeof(float));
+		if (version >= 0x108)
+		{
+			file.write(reinterpret_cast<char*>(&water.zones[0][0].type), sizeof(int));
+			file.write(reinterpret_cast<char*>(&water.zones[0][0].amplitude), sizeof(float));
+			file.write(reinterpret_cast<char*>(&water.zones[0][0].waveSpeed), sizeof(float));
+			file.write(reinterpret_cast<char*>(&water.zones[0][0].wavePitch), sizeof(float));
+		}
+		if (version >= 0x109)
+			file.write(reinterpret_cast<char*>(&water.zones[0][0].textureAnimSpeed), sizeof(int));
+		else
+		{
+			water.zones[0][0].textureAnimSpeed = 100;
+			throw "todo";
+		}
 	}
 
 	if (version >= 0x105)
@@ -550,7 +560,7 @@ void Rsw::save(const std::string& fileName, BrowEdit* browEdit)
 	std::vector<LubEffect*> lubEffects;
 	for (auto i = 0; i < objects.size(); i++)
 	{
-		objects[i]->getComponent<RswObject>()->save(file, version);
+		objects[i]->getComponent<RswObject>()->save(file, this);
 		auto light = objects[i]->getComponent<RswLight>();
 		if (light)
 		{
@@ -645,7 +655,9 @@ void Rsw::newMap(const std::string& fileName, int width, int height, Map* map, B
 	light.diffuse = glm::vec3(1, 1, 1);
 	light.ambient = glm::vec3(0.8f, 0.8f, 0.8f);
 	light.intensity = 0.5f;
-	water.height = 10;
+	water.splitWidth = 1;
+	water.splitHeight = 1;
+	water.zones.resize(water.splitWidth, std::vector<Rsw::Water>(water.splitHeight));
 	gndFile = fileName;
 	if (gndFile.find("\\"))
 		gndFile = gndFile.substr(gndFile.rfind("\\") + 1);
@@ -776,23 +788,106 @@ void Rsw::buildImGui(BrowEdit* browEdit)
 	}
 	if (ImGui::CollapsingHeader("Water", ImGuiTreeNodeFlags_DefaultOpen))
 	{
-		if (util::DragInt(browEdit, browEdit->activeMapView->map, node, "Type", &water.type, 1, 0, 1000))
-		{
-			auto waterRenderer = node->getComponent<WaterRenderer>();
-			waterRenderer->reloadTextures();
-		}
-		if (util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Height", &water.height, 0.1f, -100, 100)) {
-			auto waterRenderer = node->getComponent<WaterRenderer>();
+		auto gnd = browEdit->activeMapView->map->rootNode->getComponent<Gnd>();
 
-			if (!waterRenderer->renderFullWater) {
-				waterRenderer->renderFullWater = true;
+		if (gnd && gnd->version >= 0x108) {
+			if (util::DragInt(browEdit, browEdit->activeMapView->map, node, "Split width", &water.splitWidth, 1, 1, 10, "", [&](int* ptr, int startValue) {
+				water.splitWidth = glm::max(1, water.splitWidth);
+				water.splitHeight = glm::max(1, water.splitHeight);
+				auto action = new WaterSplitChangeAction(water, startValue, water.splitHeight);
+				browEdit->activeMapView->map->doAction(action, browEdit);
+				})) {
+				water.resize(water.splitWidth, water.splitHeight);
+				auto waterRenderer = node->getComponent<WaterRenderer>();
 				waterRenderer->setDirty();
 			}
+
+			if (util::DragInt(browEdit, browEdit->activeMapView->map, node, "Split height", &water.splitHeight, 1, 1, 10, "", [&](int* ptr, int startValue) {
+				water.splitWidth = glm::max(1, water.splitWidth);
+				water.splitHeight = glm::max(1, water.splitHeight);
+				auto action = new WaterSplitChangeAction(water, glm::max(1, water.splitWidth), startValue);
+				browEdit->activeMapView->map->doAction(action, browEdit);
+				})) {
+				water.resize(water.splitWidth, water.splitHeight);
+				auto waterRenderer = node->getComponent<WaterRenderer>();
+				waterRenderer->setDirty();
+			}
+
+			if (gnd->version >= 0x109) {
+				for (int y = 0; y < water.splitHeight; y++) {
+					for (int x = 0; x < water.splitWidth; x++) {
+						ImGui::LabelText("", "Water zone: x:%d - y:%d", x, y);
+
+						std::string uid = std::to_string(x) + "_" + std::to_string(y);
+
+						if (util::DragInt(browEdit, browEdit->activeMapView->map, node, ("Type##" + uid).c_str(), &water.zones[x][y].type, 1, 0, 1000))
+						{
+							auto waterRenderer = node->getComponent<WaterRenderer>();
+							waterRenderer->reloadTextures();
+						}
+						if (util::DragFloat(browEdit, browEdit->activeMapView->map, node, ("Height##" + uid).c_str(), &water.zones[x][y].height, 0.1f, -100, 100)) {
+							auto waterRenderer = node->getComponent<WaterRenderer>();
+
+							if (!waterRenderer->renderFullWater) {
+								waterRenderer->renderFullWater = true;
+								waterRenderer->setDirty();
+							}
+						}
+						util::DragFloat(browEdit, browEdit->activeMapView->map, node, ("Wave Height##" + uid).c_str(), &water.zones[x][y].amplitude, 0.1f, -100, 100);
+						util::DragInt(browEdit, browEdit->activeMapView->map, node, ("Texture Animation Speed##" + uid).c_str(), &water.zones[x][y].textureAnimSpeed, 1, 0, 1000);
+						util::DragFloat(browEdit, browEdit->activeMapView->map, node, ("Wave Speed##" + uid).c_str(), &water.zones[x][y].waveSpeed, 0.1f, -100, 100);
+						util::DragFloat(browEdit, browEdit->activeMapView->map, node, ("Wave Pitch##" + uid).c_str(), &water.zones[x][y].wavePitch, 0.1f, -100, 100);
+					}
+				}
+			}
+			else {	// 0x108
+				if (util::DragInt(browEdit, browEdit->activeMapView->map, node, "Type", &water.zones[0][0].type, 1, 0, 1000))
+				{
+					auto waterRenderer = node->getComponent<WaterRenderer>();
+					waterRenderer->reloadTextures();
+				}
+				util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Height", &water.zones[0][0].amplitude, 0.1f, -100, 100);
+				util::DragInt(browEdit, browEdit->activeMapView->map, node, "Texture Animation Speed", &water.zones[0][0].textureAnimSpeed, 1, 0, 1000);
+				util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Speed", &water.zones[0][0].waveSpeed, 0.1f, -100, 100);
+				util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Pitch", &water.zones[0][0].wavePitch, 0.1f, -100, 100);
+				
+				for (int y = 0; y < water.splitHeight; y++) {
+					for (int x = 0; x < water.splitWidth; x++) {
+						ImGui::LabelText("", "Water zone: x:%d - y:%d", x, y);
+
+						std::string uid = std::to_string(x) + "_" + std::to_string(y);
+
+						if (util::DragFloat(browEdit, browEdit->activeMapView->map, node, ("Height##" + uid).c_str(), &water.zones[x][y].height, 0.1f, -100, 100)) {
+							auto waterRenderer = node->getComponent<WaterRenderer>();
+
+							if (!waterRenderer->renderFullWater) {
+								waterRenderer->renderFullWater = true;
+								waterRenderer->setDirty();
+							}
+						}
+					}
+				}
+			}
 		}
-		util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Height", &water.amplitude, 0.1f, -100, 100);
-		util::DragInt(browEdit, browEdit->activeMapView->map, node, "Texture Animation Speed", &water.textureAnimSpeed, 1, 0, 1000);
-		util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Speed", &water.waveSpeed, 0.1f, -100, 100);
-		util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Pitch", &water.wavePitch, 0.1f, -100, 100);
+		else {
+			if (util::DragInt(browEdit, browEdit->activeMapView->map, node, "Type", &water.zones[0][0].type, 1, 0, 1000))
+			{
+				auto waterRenderer = node->getComponent<WaterRenderer>();
+				waterRenderer->reloadTextures();
+			}
+			if (util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Height", &water.zones[0][0].height, 0.1f, -100, 100)) {
+				auto waterRenderer = node->getComponent<WaterRenderer>();
+
+				if (!waterRenderer->renderFullWater) {
+					waterRenderer->renderFullWater = true;
+					waterRenderer->setDirty();
+				}
+			}
+			util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Height", &water.zones[0][0].amplitude, 0.1f, -100, 100);
+			util::DragInt(browEdit, browEdit->activeMapView->map, node, "Texture Animation Speed", &water.zones[0][0].textureAnimSpeed, 1, 0, 1000);
+			util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Speed", &water.zones[0][0].waveSpeed, 0.1f, -100, 100);
+			util::DragFloat(browEdit, browEdit->activeMapView->map, node, "Wave Pitch", &water.zones[0][0].wavePitch, 0.1f, -100, 100);
+		}
 	}
 
 	if (ImGui::CollapsingHeader("Fog", ImGuiTreeNodeFlags_DefaultOpen))
@@ -822,8 +917,21 @@ void Rsw::recalculateQuadtree(QuadTreeNode* node)
 
 		heights.clear();
 		heights.resize(gnd->width);
-		for (int i = 0; i < gnd->width; i++)
-			heights[i].resize(gnd->height, glm::vec2(rsw->water.height, rsw->water.height));
+
+		if (rsw->water.splitHeight == 1 && rsw->water.splitWidth == 1) {
+			for (int i = 0; i < gnd->width; i++) {
+				heights[i].resize(gnd->height, glm::vec2(-rsw->water.zones[0][0].height, -rsw->water.zones[0][0].height));
+			}
+		}
+		else {
+			// This could use an improvement...
+			for (int x = 0; x < gnd->width; x++) {
+				for (int y = 0; y < gnd->height; y++) {
+					auto water = rsw->water.getFromGnd(x, gnd->height - y - 1, gnd);
+					heights[x].push_back(glm::vec2(-water->height, -water->height));
+				}
+			}
+		}
 
 		debugPoints.clear();
 		debugPoints.resize(2);
@@ -1255,4 +1363,32 @@ void Rsw::KeyFrameData<Rsw::CameraTarget>::buildEditor()
 	}
 	ImGui::DragFloat("Rotation Speed", &data.turnSpeed, 0.01f, 0.0, 1.0f);
 
+}
+
+Rsw::Water* Rsw::WaterData::getFromGat(int x, int y, Gnd* gnd) {
+	return &zones[glm::min(splitWidth - 1, (x / 2) / (gnd->width / splitWidth))][glm::min(splitHeight - 1, (y / 2) / (gnd->height / splitHeight))];
+}
+
+Rsw::Water* Rsw::WaterData::getFromGnd(int x, int y, Gnd* gnd) {
+	return &zones[glm::min(splitWidth - 1, x / (gnd->width / splitWidth))][glm::min(splitHeight - 1, y / (gnd->height / splitHeight))];
+}
+
+void Rsw::WaterData::resize(int width, int height) {
+	for (int y = 0; y < zones.size(); y++) {
+		if (zones[y].size() < height) {
+			for (int x = (int)zones[y].size(); x < height; x++) {
+				zones[y].push_back(Rsw::Water());
+			}
+		}
+	}
+
+	for (int y = (int)zones.size(); y < width; y++) {
+		zones.push_back(std::vector<Rsw::Water>(splitHeight));
+
+		if (zones[y].size() < height) {
+			for (int x = (int)zones[y].size(); x < height; x++) {
+				zones[y].push_back(Rsw::Water());
+			}
+		}
+	}
 }

--- a/browedit/components/Rsw.h
+++ b/browedit/components/Rsw.h
@@ -21,7 +21,7 @@ class Rsw : public Component, public ImguiProps
 {
 public:
 	short version = 0x201;
-	unsigned char buildNumber = 0;
+	int buildNumber = 0;
 	std::string iniFile;
 	std::string gndFile;
 	std::string gatFile;
@@ -40,7 +40,7 @@ public:
 		void draw(int);
 	};
 
-	struct
+	struct Water
 	{
 		float	height = 0;
 		int		type = 0;
@@ -48,7 +48,20 @@ public:
 		float	waveSpeed = 2.0f;
 		float	wavePitch = 50.0f;
 		int		textureAnimSpeed = 3;
-	} water;
+	};
+
+	class WaterData
+	{
+	public:
+		int splitWidth = 0;
+		int splitHeight = 0;
+
+		std::vector<std::vector<Water>> zones;
+
+		Water* getFromGat(int x, int y, Gnd* gnd);
+		Water* getFromGnd(int x, int y, Gnd* gnd);
+		void resize(int width, int height);
+	};
 
 	struct
 	{
@@ -133,7 +146,7 @@ public:
 	std::vector<glm::vec3> quadtreeFloats;
 	QuadTreeNode* quadtree = nullptr;
 	std::map<std::string, std::map<std::string, glm::vec4>> colorPresets;
-
+	WaterData water;
 
 	Rsw();
 	~Rsw();
@@ -157,7 +170,7 @@ public:
 	RswObject() {}
 	RswObject(RswObject* other);
 	void load(std::istream* is, int version, unsigned char buildNumber, bool loadModel);
-	void save(std::ofstream& file, int version);
+	void save(std::ofstream& file, Rsw *rsw);
 	static void buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>&);
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE(RswObject, position, rotation, scale);
 };
@@ -183,7 +196,7 @@ public:
 	RswModel(RswModel* other);
 	void load(std::istream* is, int version, unsigned char buildNumber, bool loadModel);
 	void loadExtra(nlohmann::json data);
-	void save(std::ofstream &file, int version);
+	void save(std::ofstream &file, int version, int buildNumber);
 	nlohmann::json saveExtra();
 	static void buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>&);
 

--- a/browedit/components/WaterRenderer.cpp
+++ b/browedit/components/WaterRenderer.cpp
@@ -32,43 +32,73 @@ void WaterRenderer::render()
 {
 	if (!this->rsw || dirty)
 	{ //todo: move a tryLoadGnd method
+		this->gnd = node->getComponent<Gnd>();
 		this->rsw = node->getComponent<Rsw>();
-		if (rsw)
-		{
-			reloadTextures();
+		
+		if (!rsw) {
+			dirty = false;
+			return;
 		}
+
+		reloadTextures();
 
 		if (!vbo || dirty)
 		{
-			auto gnd = node->getComponent<Gnd>();
 			float waveHeight = -9999;
 
-			if (rsw)
-				waveHeight = rsw->water.height - rsw->water.amplitude;
+			int perWidth = gnd->width / glm::max(1, rsw->water.splitWidth);
+			int perHeight = gnd->height / glm::max(1, rsw->water.splitHeight);
+			int prevOffset = 0;
 
-			if(!vbo)
+			if (!vbo)
 				vbo = new gl::VBO<VertexP3T2>();
+			
+			vertIndices.clear();
 			std::vector<VertexP3T2> verts;
-			for (int x = 0; x < gnd->width; x++)
-			{
-				for (int y = 0; y < gnd->height; y++)
-				{
-					auto c = gnd->cubes[x][gnd->height - y - 1];
 
-					if (!this->renderFullWater) {
-						if (c->tileUp == -1)
-							continue;
+			for (int yy = rsw->water.splitHeight - 1; yy >= 0; yy--) {
+				for (int xx = 0; xx < rsw->water.splitWidth; xx++) {
+					auto water = &rsw->water.zones[xx][rsw->water.splitHeight - yy - 1];
 
-						if (c->heights[0] <= waveHeight && c->heights[1] <= waveHeight && c->heights[2] <= waveHeight && c->heights[3] <= waveHeight)
-							continue;
+					waveHeight = water->height - water->amplitude;
+
+					int xmax = perWidth * (xx + 1);
+
+					if (xx == rsw->water.splitWidth - 1)
+						xmax = gnd->width;
+
+					int ymax = perHeight * (yy + 1);
+
+					if (ymax == rsw->water.splitHeight - 1)
+						ymax = gnd->height;
+
+					int vertsCount = 0;
+
+					for (int x = perWidth * xx; x < xmax; x++) {
+						for (int y = perHeight * yy; y < ymax; y++) {
+							auto c = gnd->cubes[x][gnd->height - y - 1];
+
+							if (!this->renderFullWater) {
+								if (c->tileUp == -1)
+									continue;
+
+								if (c->heights[0] <= waveHeight && c->heights[1] <= waveHeight && c->heights[2] <= waveHeight && c->heights[3] <= waveHeight)
+									continue;
+							}
+					
+							verts.push_back(VertexP3T2(glm::vec3(10 * x,		0, 10 * (y+1)),	glm::vec2((x % 4) * 0.25f + 0.00f, (y % 4) * 0.25f + 0.00f)));
+							verts.push_back(VertexP3T2(glm::vec3(10 * (x+1),	0, 10 * (y+1)),	glm::vec2((x % 4) * 0.25f + 0.25f, (y % 4) * 0.25f + 0.00f)));
+							verts.push_back(VertexP3T2(glm::vec3(10 * (x+1),	0, 10 * (y+2)), glm::vec2((x % 4) * 0.25f + 0.25f, (y % 4) * 0.25f + 0.25f)));
+							verts.push_back(VertexP3T2(glm::vec3(10 * x,		0, 10 * (y+2)), glm::vec2((x % 4) * 0.25f + 0.00f, (y % 4) * 0.25f + 0.25f)));
+							vertsCount += 4;
+						}
 					}
 					
-					verts.push_back(VertexP3T2(glm::vec3(10 * x,		0, 10 * (y+1)),	glm::vec2((x % 4) * 0.25f + 0.00f, (y % 4) * 0.25f + 0.00f)));
-					verts.push_back(VertexP3T2(glm::vec3(10 * (x+1),	0, 10 * (y+1)),	glm::vec2((x % 4) * 0.25f + 0.25f, (y % 4) * 0.25f + 0.00f)));
-					verts.push_back(VertexP3T2(glm::vec3(10 * (x+1),	0, 10 * (y+2)), glm::vec2((x % 4) * 0.25f + 0.25f, (y % 4) * 0.25f + 0.25f)));
-					verts.push_back(VertexP3T2(glm::vec3(10 * x,		0, 10 * (y+2)), glm::vec2((x % 4) * 0.25f + 0.00f, (y % 4) * 0.25f + 0.25f)));
+					vertIndices.push_back(VboIndex(32 * (int)vertIndices.size(), prevOffset, vertsCount));
+					prevOffset += vertsCount;
 				}
 			}
+
 			vbo->setData(verts, GL_STATIC_DRAW);
 			dirty = false;
 		}
@@ -83,12 +113,6 @@ void WaterRenderer::render()
 
 	auto shader = dynamic_cast<WaterRenderContext*>(renderContext)->shader;
 	shader->setUniform(WaterShader::Uniforms::time, time);
-	shader->setUniform(WaterShader::Uniforms::waterHeight, -rsw->water.height);
-	shader->setUniform(WaterShader::Uniforms::amplitude, rsw->water.amplitude);
-	shader->setUniform(WaterShader::Uniforms::waveSpeed, rsw->water.waveSpeed);
-	shader->setUniform(WaterShader::Uniforms::wavePitch, rsw->water.wavePitch);
-	shader->setUniform(WaterShader::Uniforms::frameTime, glm::fract(time * 60 / rsw->water.textureAnimSpeed));
-
 	shader->setUniform(WaterShader::Uniforms::fogEnabled, viewFog);
 	shader->setUniform(WaterShader::Uniforms::fogNear, rsw->fog.nearPlane * 240 * 2.5f);
 	shader->setUniform(WaterShader::Uniforms::fogFar, rsw->fog.farPlane * 240 * 2.5f);
@@ -98,34 +122,60 @@ void WaterRenderer::render()
 	glDepthMask(0);
 	glEnable(GL_BLEND);
 	vbo->bind();
-	glActiveTexture(GL_TEXTURE0);
-	textures[((int)(time*60/rsw->water.textureAnimSpeed)) % textures.size()]->bind();
-	glActiveTexture(GL_TEXTURE1);
-	textures[((int)((time*60 / rsw->water.textureAnimSpeed))+1) % textures.size()]->bind();
-	glActiveTexture(GL_TEXTURE0);
 
-	glVertexAttribPointer(0, 3, GL_FLOAT, false, sizeof(VertexP3T2), (void*)(0 * sizeof(float)));
-	glVertexAttribPointer(1, 2, GL_FLOAT, false, sizeof(VertexP3T2), (void*)(3 * sizeof(float)));
-	glDrawArrays(GL_QUADS, 0, (int)vbo->size());
+	for (int y = 0; y < rsw->water.splitHeight; y++) {
+		for (int x = 0; x < rsw->water.splitWidth; x++) {
+			auto water = &rsw->water.zones[x][y];
 
+			shader->setUniform(WaterShader::Uniforms::waterHeight, -water->height);
+
+			if (gnd && gnd->version <= 0x108) {
+				water = &rsw->water.zones[0][0];
+				shader->setUniform(WaterShader::Uniforms::amplitude, water->amplitude);
+				shader->setUniform(WaterShader::Uniforms::waveSpeed, water->waveSpeed);
+				shader->setUniform(WaterShader::Uniforms::wavePitch, water->wavePitch);
+			}
+			else {
+				shader->setUniform(WaterShader::Uniforms::waterHeight, -water->height);
+				shader->setUniform(WaterShader::Uniforms::amplitude, water->amplitude);
+				shader->setUniform(WaterShader::Uniforms::waveSpeed, water->waveSpeed);
+				shader->setUniform(WaterShader::Uniforms::wavePitch, water->wavePitch);
+			}
+
+			int vertIndex = y * rsw->water.splitWidth + x;
+			int index = ((int)(time * 60 / water->textureAnimSpeed)) % 32;
+			textures[(gnd && gnd->version <= 0x108 ? 0 : vertIndices[vertIndex].texture) + index]->bind();
+			glVertexAttribPointer(0, 3, GL_FLOAT, false, sizeof(VertexP3T2), (void*)(0 * sizeof(float)));
+			glVertexAttribPointer(1, 2, GL_FLOAT, false, sizeof(VertexP3T2), (void*)(3 * sizeof(float)));
+			glDrawArrays(GL_QUADS, (int)vertIndices[vertIndex].begin, (int)vertIndices[vertIndex].count);
+		}
+	}
 
 	glDepthMask(1);
-
-	
 }
 
 
 void WaterRenderer::reloadTextures()
 {
-	for (auto t : textures)
-		util::ResourceManager<gl::Texture>::unload(t);
-	textures.clear();
-	for (int i = 0; i < 32; i++)
-	{
-		char buf[128];
-		sprintf_s(buf, 128, "data/texture/워터/water%i%02i%s", rsw->water.type, i, ".jpg");
-		textures.push_back(util::ResourceManager<gl::Texture>::load(buf));
-		//textures.back()->setTextureRepeat(true);
+	// Only reload necessary textures, it prevents lag issues
+	for (int y = 0; y < rsw->water.splitHeight; y++) {
+		for (int x = 0; x < rsw->water.splitWidth; x++) {
+			for (int i = 0; i < 32; i++) {
+				char buf[128];
+				sprintf_s(buf, 128, "data/texture/워터/water%i%02i%s", rsw->water.zones[x][y].type, i, ".jpg");
+
+				int index = 32 * (y * rsw->water.splitWidth + x) + i;
+				if (index >= textures.size()) {
+					textures.push_back(util::ResourceManager<gl::Texture>::load(buf));
+				}
+				else {
+					if (textures[index]->fileName != buf) {
+						util::ResourceManager<gl::Texture>::unload(textures[index]);
+						textures[index] = util::ResourceManager<gl::Texture>::load(buf);
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/browedit/components/WaterRenderer.h
+++ b/browedit/components/WaterRenderer.h
@@ -13,6 +13,7 @@ namespace gl
 	class Texture;
 }
 class Rsw;
+class Gnd;
 class WaterShader;
 
 class WaterRenderer : public Renderer
@@ -27,9 +28,25 @@ public:
 		virtual void preFrame(const glm::mat4& projectionMatrix, const glm::mat4& viewMatrix) override;
 	};
 
+	class VboIndex
+	{
+	public:
+		int texture;
+		std::size_t begin;
+		std::size_t count;
+		VboIndex(int texture, std::size_t begin, std::size_t count)
+		{
+			this->texture = texture;
+			this->begin = begin;
+			this->count = count;
+		}
+	};
+
 	std::vector<gl::Texture*> textures;
 	Rsw* rsw;
+	Gnd* gnd;
 	gl::VBO<VertexP3T2>* vbo = nullptr;
+	std::vector<VboIndex> vertIndices;
 	bool dirty = true;
 	bool viewFog = false;
 	bool renderFullWater = false;

--- a/browedit/shaders/WaterShader.h
+++ b/browedit/shaders/WaterShader.h
@@ -19,7 +19,6 @@ public:
 			amplitude,
 			waveSpeed,
 			wavePitch,
-			frameTime,
 			fogEnabled,
 			fogColor,
 			fogNear,
@@ -40,7 +39,6 @@ public:
 		bindUniform(Uniforms::amplitude, "amplitude");
 		bindUniform(Uniforms::waveSpeed, "waveSpeed");
 		bindUniform(Uniforms::wavePitch, "wavePitch");
-		bindUniform(Uniforms::frameTime, "frameTime");
 		bindUniform(Uniforms::fogEnabled, "fogEnabled");
 		bindUniform(Uniforms::fogColor, "fogColor");
 		bindUniform(Uniforms::fogNear, "fogNear");

--- a/browedit/util/Util.cpp
+++ b/browedit/util/Util.cpp
@@ -208,15 +208,19 @@ namespace util
 		return ret;
 	}
 
-	bool DragInt(BrowEdit* browEdit, Map* map, Node* node, const char* label, int* ptr, float v_speed, int v_min, int v_max, const std::string& action)
+	bool DragInt(BrowEdit* browEdit, Map* map, Node* node, const char* label, int* ptr, float v_speed, int v_min, int v_max, const std::string& action, const std::function<void(int*, int)>& editAction)
 	{
 		static int startValue;
 		bool ret = ImGui::DragInt(label, ptr, v_speed, v_min, v_max);
 
 		if (ImGui::IsItemActivated())
 			startValue = *ptr;
-		if (ImGui::IsItemDeactivatedAfterEdit())
-			map->doAction(new ObjectChangeAction(node, ptr, startValue, action == "" ? label : action), browEdit);
+		if (ImGui::IsItemDeactivatedAfterEdit()) {
+			if (editAction != nullptr)
+				editAction(ptr, startValue);
+			else
+				map->doAction(new ObjectChangeAction(node, ptr, startValue, action == "" ? label : action), browEdit);
+		}
 		ImGui::PushID(label);
 		if (ImGui::BeginPopupContextItem("CopyPaste"))
 		{
@@ -232,7 +236,10 @@ namespace util
 					{
 						startValue = *ptr;
 						*ptr = std::stoi(cb);
-						map->doAction(new ObjectChangeAction(node, ptr, startValue, action == "" ? label : action), browEdit);
+						if (editAction != nullptr)
+							editAction(ptr, startValue);
+						else
+							map->doAction(new ObjectChangeAction(node, ptr, startValue, action == "" ? label : action), browEdit);
 						ret = true;
 					}
 				}

--- a/browedit/util/Util.h
+++ b/browedit/util/Util.h
@@ -45,7 +45,7 @@ namespace util
 
 	bool ColorEdit3(BrowEdit* browEdit, Map* map, Node* node, const char* label, glm::vec3* ptr, const std::string& action = "");
 	bool ColorEdit4(BrowEdit* browEdit, Map* map, Node* node, const char* label, glm::vec4* ptr, const std::string& action = "");
-	bool DragInt(BrowEdit* browEdit, Map* map, Node* node, const char* label, int* ptr, float v_speed = 1, int v_min = 0.0f, int v_max = 0.0f, const std::string& action = "");
+	bool DragInt(BrowEdit* browEdit, Map* map, Node* node, const char* label, int* ptr, float v_speed = 1, int v_min = 0.0f, int v_max = 0.0f, const std::string& action = "", const std::function<void(int*, int)>& editAction = nullptr);
 	bool DragFloat(BrowEdit* browEdit, Map* map, Node* node, const char* label, float* ptr, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const std::string& action = "");
 	bool DragFloat2(BrowEdit* browEdit, Map* map, Node* node, const char* label, glm::vec2* ptr, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const std::string& action = "");
 	bool DragFloat3(BrowEdit* browEdit, Map* map, Node* node, const char* label, glm::vec3* ptr, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const std::string& action = "", bool moveTogether = false);

--- a/browedit/windows/GatEditWindow.cpp
+++ b/browedit/windows/GatEditWindow.cpp
@@ -325,9 +325,12 @@ void BrowEdit::showGatWindow()
 							if (blockUnderWater)
 							{
 								bool underWater = false;
-								for (int i = 0; i < 4; i++)
-									if (gat->cubes[x][y]->heights[i] > rsw->water.height)
+								for (int i = 0; i < 4; i++) {
+									auto water = rsw->water.getFromGat(x, y, gnd);
+
+									if (gat->cubes[x][y]->heights[i] > water->height)
 										underWater = true;
+								}
 								if (underWater)
 									gat->cubes[x][y]->gatType = 1;
 							}
@@ -394,8 +397,10 @@ void BrowEdit::showGatWindow()
 											height.y = glm::max(height.y, c.y);
 									}
 									});
-								gat->cubes[x][y]->heights[i] = rsw->water.height;
-								underWater |= height.y < -rsw->water.height;
+
+								auto water = rsw->water.getFromGat(x, y, gnd);
+								gat->cubes[x][y]->heights[i] = water->height;
+								underWater |= height.y < -water->height;
 							}
 							gat->cubes[x][y]->gatType = underWater ? 0 : 1;
 						}

--- a/data/shaders/water.fs
+++ b/data/shaders/water.fs
@@ -4,8 +4,6 @@ in vec3 normal;
 in vec2 texCoord;
 
 uniform sampler2D s_texture;
-uniform sampler2D s_textureNext;
-uniform float frameTime;
 
 uniform bool fogEnabled;
 uniform float fogNear = 0;
@@ -16,18 +14,15 @@ uniform vec4 fogColor = vec4(1,1,1,1);
 
 void main()
 {
-    vec4 color = texture2D(s_texture, texCoord); 
-    vec4 color2 = texture2D(s_textureNext, texCoord); 
+    vec4 color = texture2D(s_texture, texCoord);
     color.a = 0.564;
-    color2.a = 0.564;
 
-    vec4 texture = mix(color, color2, frameTime);
     if(fogEnabled)
 	{
 		float depth = gl_FragCoord.z / gl_FragCoord.w;
 		float fogAmount = smoothstep(fogNear, fogFar, depth);
-		texture = mix(texture, fogColor, fogAmount);
+		color = mix(color, fogColor, fogAmount);
 	}
-    fragColor = texture;
+    fragColor = color;
 
 }

--- a/data/shaders/water.vs
+++ b/data/shaders/water.vs
@@ -20,13 +20,11 @@ out vec2 texCoord;
 
 void main()
 {
-	mat3 normalMatrix = mat3(viewMatrix * modelMatrix);
-	normalMatrix = transpose(inverse(normalMatrix));
 	texCoord = a_texcoord;
-//	normal = normalMatrix * a_normal;
 
 	float height = waterHeight;
-	height += amplitude*cos(radians((waveSpeed*16.6667*time)+(a_position.x-a_position.z)*.1*wavePitch));
+	//height += amplitude*cos(radians((waveSpeed*16.6667*time)+(a_position.x-a_position.z)*.1*wavePitch));
+	height += amplitude*cos(radians((waveSpeed*50*time)+(a_position.x-a_position.z)*.1*wavePitch));
 
 
 	gl_Position = projectionMatrix * viewMatrix * modelMatrix * vec4(vec3(a_position.x, height, a_position.z),1);


### PR DESCRIPTION
Added better support for GND versions 0x108 and 0x109.
Added better support for RSW version 0x206.
Changed the zNear value depending of the camera distance (it caused rendering issues with low water wave height).
Fixed a dirty chunk issue when the tile is a chunk's corner.
Show black edges for tileUp -1.
Removed water texture blending (it's barely noticeable and the client doesn't do that).
Increased water wave speed in the shader from 16.6 to 50 (a bit more accurate, but it's still off).
Fixed negative gat type rendering (what's going on at Gravity...).
Fixed the water height being reversed during quadtree calculation.