### PR TITLE
Shadow edit mode.

### DIFF
--- a/BrowEdit3.vcxproj
+++ b/BrowEdit3.vcxproj
@@ -18,6 +18,7 @@
     <ClCompile Include="browedit\actions\GndTextureActions.cpp" />
     <ClCompile Include="browedit\actions\GndVersionChangeAction.cpp" />
     <ClCompile Include="browedit\actions\GroupAction.cpp" />
+    <ClCompile Include="browedit\actions\LightmapNewAction.cpp" />
     <ClCompile Include="browedit\actions\ModelChangeAction.cpp" />
     <ClCompile Include="browedit\actions\NewObjectAction.cpp" />
     <ClCompile Include="browedit\actions\ObjectChangeAction.cpp" />
@@ -66,6 +67,7 @@
     <ClCompile Include="browedit\MapView.Gatmode.cpp" />
     <ClCompile Include="browedit\MapView.Heightmode.cpp" />
     <ClCompile Include="browedit\MapView.Objectmode.cpp" />
+    <ClCompile Include="browedit\MapView.Shadowmode.cpp" />
     <ClCompile Include="browedit\MapView.Texturemode.cpp" />
     <ClCompile Include="browedit\MapView.Wallmode.cpp" />
     <ClCompile Include="browedit\math\AABB.cpp" />
@@ -93,6 +95,7 @@
     <ClCompile Include="browedit\windows\ObjectSelectWindow.cpp" />
     <ClCompile Include="browedit\windows\ObjectTreeWindow.cpp" />
     <ClCompile Include="browedit\windows\OpenMapWindow.cpp" />
+    <ClCompile Include="browedit\windows\ShadowEditWindow.cpp" />
     <ClCompile Include="browedit\windows\TextureBrushWindow.cpp" />
     <ClCompile Include="browedit\windows\TextureManageWindow.cpp" />
     <ClCompile Include="browedit\windows\Toolbar.cpp" />
@@ -140,6 +143,7 @@
     <ClInclude Include="browedit\actions\GndTextureActions.h" />
     <ClInclude Include="browedit\actions\GndVersionChangeAction.h" />
     <ClInclude Include="browedit\actions\GroupAction.h" />
+    <ClInclude Include="browedit\actions\LightmapNewAction.h" />
     <ClInclude Include="browedit\actions\ModelChangeAction.h" />
     <ClInclude Include="browedit\actions\NewObjectAction.h" />
     <ClInclude Include="browedit\actions\ObjectChangeAction.h" />

--- a/BrowEdit3.vcxproj.filters
+++ b/BrowEdit3.vcxproj.filters
@@ -418,6 +418,15 @@
     <ClCompile Include="browedit\actions\GndVersionChangeAction.cpp">
       <Filter>browedit\actions</Filter>
     </ClCompile>
+    <ClCompile Include="browedit\windows\ShadowEditWindow.cpp">
+      <Filter>browedit\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="browedit\MapView.Shadowmode.cpp">
+      <Filter>browedit</Filter>
+    </ClCompile>
+    <ClCompile Include="browedit\actions\LightmapNewAction.cpp">
+      <Filter>browedit\actions</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\imgui\imgui.h">
@@ -721,6 +730,9 @@
       <Filter>browedit\actions</Filter>
     </ClInclude>
     <ClInclude Include="browedit\actions\GndVersionChangeAction.h">
+      <Filter>browedit\actions</Filter>
+    </ClInclude>
+    <ClInclude Include="browedit\actions\LightmapNewAction.h">
       <Filter>browedit\actions</Filter>
     </ClInclude>
   </ItemGroup>

--- a/browedit/BrowEdit.cpp
+++ b/browedit/BrowEdit.cpp
@@ -267,6 +267,8 @@ void BrowEdit::run()
 		}
 		if (editMode == EditMode::Color)
 			showColorEditWindow();
+		if (editMode == EditMode::Shadow)
+			showShadowEditWindow();
 		if (editMode == EditMode::Cinematic)
 			showCinematicModeWindow();
 
@@ -572,6 +574,8 @@ void BrowEdit::showMapWindow(MapView& mapView, float deltaTime)
 					mapView.postRenderWallMode(this);
 				else if (editMode == EditMode::Color)
 					mapView.postRenderColorMode(this);
+				else if (editMode == EditMode::Shadow)
+					mapView.postRenderShadowMode(this);
 				else if (editMode == EditMode::Cinematic)
 					mapView.postRenderCinematicMode(this);
 			}

--- a/browedit/BrowEdit.h
+++ b/browedit/BrowEdit.h
@@ -278,6 +278,9 @@ public:
 	int			colorEditBrushSize = 1;
 	float		colorEditBrushHardness = 1.0f;
 
+	int		shadowEditBrushAlpha = 128;
+	int		shadowEditBrushSize = 1;
+	bool	shadowSmoothEdges = true;
 
 	void configBegin();
 
@@ -327,6 +330,7 @@ public:
 	void showTextureManageWindow();
 	void showHotkeyEditorWindow();
 	void showColorEditWindow();
+	void showShadowEditWindow();
 	void showCinematicModeWindow();
 
 	void copyTiles();

--- a/browedit/MapView.Shadowmode.cpp
+++ b/browedit/MapView.Shadowmode.cpp
@@ -1,0 +1,283 @@
+#include <Windows.h>
+#include "MapView.h"
+#include <browedit/BrowEdit.h>
+#include <browedit/shaders/SimpleShader.h>
+#include <browedit/gl/FBO.h>
+#include <browedit/Map.h>
+#include <browedit/components/Rsw.h>
+#include <browedit/components/Gnd.h>
+#include <browedit/components/GndRenderer.h>
+#include <browedit/Node.h>
+#include <browedit/actions/GroupAction.h>
+#include <browedit/actions/TilePropertyChangeAction.h>
+#include <browedit/actions/TileNewAction.h>
+#include <browedit/actions/LightmapNewAction.h>
+#include <glm/gtc/type_ptr.hpp>
+#include <GLFW/glfw3.h>
+#include <unordered_set>
+
+extern bool shadowDropperEnabled;
+
+void MapView::postRenderShadowMode(BrowEdit* browEdit)
+{
+	auto rsw = map->rootNode->getComponent<Rsw>();
+	auto gnd = map->rootNode->getComponent<Gnd>();
+	auto gndRenderer = map->rootNode->getComponent<GndRenderer>();
+
+	glUseProgram(0);
+	glMatrixMode(GL_PROJECTION);
+	glLoadMatrixf(glm::value_ptr(nodeRenderContext.projectionMatrix));
+	glMatrixMode(GL_MODELVIEW);
+	glLoadMatrixf(glm::value_ptr(nodeRenderContext.viewMatrix));
+	glColor3f(1, 0, 0);
+	fbo->bind();
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glDisable(GL_TEXTURE_2D);
+
+	simpleShader->use();
+	simpleShader->setUniform(SimpleShader::Uniforms::projectionMatrix, nodeRenderContext.projectionMatrix);
+	simpleShader->setUniform(SimpleShader::Uniforms::viewMatrix, nodeRenderContext.viewMatrix);
+	simpleShader->setUniform(SimpleShader::Uniforms::modelMatrix, glm::mat4(1.0f));
+	simpleShader->setUniform(SimpleShader::Uniforms::textureFac, 0.0f);
+	glEnable(GL_BLEND);
+	glDepthMask(0);
+
+	auto mouse3D = gnd->rayCast(mouseRay, viewEmptyTiles);
+	glm::ivec2 tileHovered((int)glm::floor(mouse3D.x / 10), (gnd->height - (int)glm::floor(mouse3D.z) / 10));
+	glm::ivec2 subTileHovered((int)glm::floor(glm::fract(mouse3D.x / 10) * gnd->lightmapWidth), gnd->lightmapHeight - (int)glm::floor(glm::fract(mouse3D.z / 10) * gnd->lightmapHeight));
+	glm::ivec2 shadowHoveredOffset((int)glm::floor(mouse3D.x / 10 * gnd->lightmapWidth), (int)((gnd->height - (mouse3D.z - 10) / 10) * gnd->lightmapHeight));
+
+	ImGui::Begin("Statusbar");
+	ImGui::SetNextItemWidth(100.0f);
+	ImGui::Text("Cursor: %d,%d", tileHovered.x, tileHovered.y);
+	ImGui::SameLine();
+	ImGui::End();
+
+	//if(hovered && ImGui::IsMouseDown(ImGuiMouseButton_Left))
+	//	refColor = browEdit->colorEditBrushColor;
+
+	if (hovered && gnd->inMap(tileHovered))
+	{
+		if (shadowDropperEnabled && gnd->cubes[tileHovered.x][tileHovered.y]->tileUp != -1)
+		{
+			if (ImGui::IsMouseReleased(ImGuiMouseButton_Left))
+			{
+				browEdit->shadowEditBrushAlpha = gnd->lightmaps[gnd->tiles[gnd->cubes[tileHovered.x][tileHovered.y]->tileUp]->lightmapIndex]->data[subTileHovered.y * gnd->lightmapWidth + subTileHovered.x];
+				shadowDropperEnabled = false;
+				browEdit->cursor = nullptr;
+			}
+		}
+		else
+		{
+			std::vector<VertexP3T2N3> verts;
+			float dist = 0.002f * cameraDistance;
+			for (int x = 0; x < browEdit->shadowEditBrushSize; x++)
+			{
+				for (int y = 0; y < browEdit->shadowEditBrushSize; y++)
+				{
+					int xx = shadowHoveredOffset.x + x - browEdit->shadowEditBrushSize / 2;
+					int yy = shadowHoveredOffset.y + y - browEdit->shadowEditBrushSize / 2;
+
+					int cx = xx / gnd->lightmapWidth;
+					int cy = yy / gnd->lightmapHeight;
+
+					if (!gnd->inMap(glm::ivec2(cx, cy)))
+						continue;
+
+					const auto cube = gnd->cubes[cx][cy];
+
+					float t, th1, th2;
+					float xxx = xx * 10.0f / gnd->lightmapWidth;
+					float yyy = gnd->height * 10 - yy * 10.0f / gnd->lightmapHeight + 10.0f;
+					int subx = xx % gnd->lightmapWidth;
+					int suby = yy % gnd->lightmapHeight;
+
+					t = (float)suby / gnd->lightmapWidth;
+					th2 = (cube->h4 - cube->h2) * t + cube->h2;
+					th1 = (cube->h3 - cube->h1) * t + cube->h1;
+					verts.push_back(VertexP3T2N3(glm::vec3(xxx, 
+						-(th2 - th1) / gnd->lightmapWidth * subx - th1 + dist,
+						yyy), glm::vec2(0), cube->normals[0]));
+					verts.push_back(VertexP3T2N3(glm::vec3(xxx + 10.0f / gnd->lightmapWidth, 
+						-(th2 - th1) / gnd->lightmapWidth * (subx + 1) - th1 + dist,
+						yyy), glm::vec2(0), cube->normals[1]));
+
+					t = (float)(subx + 1) / gnd->lightmapWidth;
+					th2 = (cube->h4 - cube->h3) * t + cube->h3;
+					th1 = (cube->h2 - cube->h1) * t + cube->h1;
+					verts.push_back(VertexP3T2N3(glm::vec3(xxx + 10.0f / gnd->lightmapWidth,
+						-(th2 - th1) / gnd->lightmapHeight * suby - th1 + dist,
+						yyy), glm::vec2(0), cube->normals[0]));
+					verts.push_back(VertexP3T2N3(glm::vec3(xxx + 10.0f / gnd->lightmapWidth,
+						-(th2 - th1) / gnd->lightmapHeight * (suby + 1) - th1 + dist,
+						yyy - 10.0f / gnd->lightmapHeight), glm::vec2(0), cube->normals[1]));
+					
+					t = (float)(suby + 1) / gnd->lightmapWidth;
+					th2 = (cube->h4 - cube->h2) * t + cube->h2;
+					th1 = (cube->h3 - cube->h1) * t + cube->h1;
+					verts.push_back(VertexP3T2N3(glm::vec3(xxx,
+						-(th2 - th1) / gnd->lightmapWidth * subx - th1 + dist,
+						yyy - 10.0f / gnd->lightmapHeight), glm::vec2(0), cube->normals[0]));
+					verts.push_back(VertexP3T2N3(glm::vec3(xxx + 10.0f / gnd->lightmapWidth,
+						-(th2 - th1) / gnd->lightmapWidth * (subx + 1) - th1 + dist,
+						yyy - 10.0f / gnd->lightmapHeight), glm::vec2(0), cube->normals[1]));
+
+					t = (float)subx / gnd->lightmapWidth;
+					th2 = (cube->h4 - cube->h3) * t + cube->h3;
+					th1 = (cube->h2 - cube->h1) * t + cube->h1;
+					verts.push_back(VertexP3T2N3(glm::vec3(xxx,
+						-(th2 - th1) / gnd->lightmapHeight * suby - th1 + dist,
+						yyy), glm::vec2(0), cube->normals[0]));
+					verts.push_back(VertexP3T2N3(glm::vec3(xxx,
+						-(th2 - th1) / gnd->lightmapHeight * (suby + 1) - th1 + dist,
+						yyy - 10.0f / gnd->lightmapHeight), glm::vec2(0), cube->normals[1]));
+				}
+			}
+			if (verts.size() > 0)
+			{
+				glEnableVertexAttribArray(0);
+				glEnableVertexAttribArray(1);
+				glEnableVertexAttribArray(2);
+				glDisableVertexAttribArray(3);
+				glDisableVertexAttribArray(4); //TODO: vao
+				glVertexAttribPointer(0, 3, GL_FLOAT, false, sizeof(VertexP3T2N3), verts[0].data);
+				glVertexAttribPointer(1, 2, GL_FLOAT, false, sizeof(VertexP3T2N3), verts[0].data + 3);
+				glVertexAttribPointer(2, 3, GL_FLOAT, false, sizeof(VertexP3T2N3), verts[0].data + 5);
+
+				simpleShader->setUniform(SimpleShader::Uniforms::color, glm::vec4(0, 1, 0, 0.75f));
+				simpleShader->setUniform(SimpleShader::Uniforms::textureFac, 0.0f);
+				simpleShader->setUniform(SimpleShader::Uniforms::lightMin, 1.0f);
+				glDrawArrays(GL_LINES, 0, (int)verts.size());
+			}
+
+			static std::unordered_set<int> tilesProcessed;
+			static std::unordered_set<int> subTilesProcessed;
+			static GroupAction* ga = nullptr;
+			static int lightmapsCount = 0;
+			
+			if (ImGui::IsMouseDown(ImGuiMouseButton_Left))
+			{
+				auto shadowProc = [&](int xx, int yy) -> bool {
+					if (subTilesProcessed.find(yy << 16 | xx) != subTilesProcessed.end()) {
+						return false;
+					}
+			
+					int subx = xx % gnd->lightmapWidth;
+					int suby = yy % gnd->lightmapHeight;
+					int cx = xx / gnd->lightmapWidth;
+					int cy = yy / gnd->lightmapHeight;
+			
+					if (!gnd->inMap(glm::ivec2(cx, cy)))
+						return false;
+			
+					const auto cube = gnd->cubes[cx][cy];
+			
+					if (cube->tileUp != -1) {
+						int count = 0;
+						Gnd::Tile* tile = gnd->tiles[cube->tileUp];
+			
+						// Happens with undo/redo while painting; though that's just a bandaid, the map will be bugged until a reload
+						if (tile->lightmapIndex >= gnd->lightmaps.size())
+							return false;
+			
+						Gnd::Lightmap* lightmap = gnd->lightmaps[tile->lightmapIndex];
+			
+						if (tilesProcessed.find(cy << 16 | cx) == tilesProcessed.end()) {
+							lightmap = new Gnd::Lightmap(*lightmap);
+							if (ga == nullptr)
+								ga = new GroupAction();
+							auto action = new LightmapNewAction(lightmap);
+							int oldLightmapIndex = tile->lightmapIndex;
+							tile->lightmapIndex = (int)gnd->lightmaps.size();
+							lightmapsCount++;
+							action->perform(map, browEdit);
+							ga->addAction(action);
+							ga->addAction(new TileChangeAction<int>(glm::ivec2(cx, cy), tile, &tile->lightmapIndex, oldLightmapIndex, ""));
+							tilesProcessed.insert(cy << 16 | cx);
+						}
+			
+						if (ImGui::GetIO().KeyShift)
+							lightmap->data[suby * gnd->lightmapWidth + subx] = 255;
+						else
+							lightmap->data[suby * gnd->lightmapWidth + subx] = (unsigned char)browEdit->shadowEditBrushAlpha;
+			
+						gndRenderer->setChunkDirty(cx, cy);
+						gndRenderer->gndShadowDirty = true;
+					}
+			
+					subTilesProcessed.insert(yy << 16 | xx);
+					return true;
+				};
+			
+				for (int x = 0; x < browEdit->shadowEditBrushSize; x++)
+				{
+					for (int y = 0; y < browEdit->shadowEditBrushSize; y++)
+					{
+						int xx = shadowHoveredOffset.x + x - browEdit->shadowEditBrushSize / 2;
+						int yy = shadowHoveredOffset.y + y - browEdit->shadowEditBrushSize / 2;
+						
+						if (!browEdit->shadowSmoothEdges) {
+							shadowProc(xx, yy);
+						}
+						else {
+							int subx = xx % gnd->lightmapWidth;
+							int suby = yy % gnd->lightmapHeight;
+			
+							if (subx <= 1 || subx >= gnd->lightmapWidth - 2) {
+								int extraX = subx <= 1 ? -2 : 2;
+			
+								if (subx == 0)
+									xx++;
+								else if (subx == gnd->lightmapWidth - 1)
+									xx--;
+			
+								if (suby == 0)
+									yy++;
+								else if (suby == gnd->lightmapHeight - 1)
+									yy--;
+			
+								shadowProc(xx + extraX, yy);
+			
+								if (suby <= 1) {
+									shadowProc(xx, yy - 2);
+									shadowProc(xx + extraX, yy - 2);
+								}
+								else if (suby >= gnd->lightmapHeight - 2) {
+									shadowProc(xx, yy + 2);
+									shadowProc(xx + extraX, yy + 2);
+								}
+							}
+							else if (suby <= 1 || suby >= gnd->lightmapHeight - 2) {
+								if (suby == 0)
+									yy++;
+								else if (suby == gnd->lightmapHeight - 1)
+									yy--;
+			
+								shadowProc(xx, yy + (suby <= 1 ? -2 : 2));
+							}
+			
+							shadowProc(xx, yy);
+						}
+					}
+				}
+			}
+
+			if (ImGui::IsMouseReleased(ImGuiMouseButton_Left) && ga != nullptr)
+			{
+				for (int i = 0; i < lightmapsCount; i++) {
+					gnd->lightmaps.pop_back();
+				}
+
+				map->doAction(ga, browEdit);
+				ga = nullptr;
+				tilesProcessed.clear();
+				subTilesProcessed.clear();
+				lightmapsCount = 0;
+			}
+		}
+	}
+
+	glDepthMask(1);
+	glDisable(GL_BLEND);
+	fbo->unbind();
+}

--- a/browedit/MapView.h
+++ b/browedit/MapView.h
@@ -189,6 +189,7 @@ public:
 	void postRenderGatMode(BrowEdit* browEdit);
 	void postRenderWallMode(BrowEdit* browEdit);
 	void postRenderColorMode(BrowEdit* browEdit);
+	void postRenderShadowMode(BrowEdit* browEdit);
 	void postRenderCinematicMode(BrowEdit* browEdit);
 
 	void gatEdit_adjustToGround(BrowEdit* browEdit);

--- a/browedit/actions/CubeHeightChangeAction.cpp
+++ b/browedit/actions/CubeHeightChangeAction.cpp
@@ -1,8 +1,10 @@
 #include "CubeHeightChangeAction.h"
 #include <browedit/Map.h>
 #include <browedit/Node.h>
+#include <browedit/BrowEdit.h>
 #include <browedit/components/GndRenderer.h>
 #include <browedit/components/GatRenderer.h>
+#include <browedit/components/WaterRenderer.h>
 #include <browedit/components/Gat.h>
 
 template<class T, class TC>
@@ -49,6 +51,12 @@ void CubeHeightChangeAction<T, TC>::perform(Map* map, BrowEdit* browEdit)
 				gndRenderer->setChunkDirty(t.x, t.y - 1);
 			}
 		}
+		auto waterRenderer = map->rootNode->getComponent<WaterRenderer>();
+		if (waterRenderer)
+			waterRenderer->setDirty();
+		for (auto& mv : browEdit->mapViews)
+			if (mv.map == map)
+				mv.textureGridDirty = true;
 	}
 	if (std::is_same<T, Gat>::value)
 	{
@@ -79,6 +87,12 @@ void CubeHeightChangeAction<T, TC>::undo(Map* map, BrowEdit* browEdit)
 				gndRenderer->setChunkDirty(t.x, t.y - 1);
 			}
 		}
+		auto waterRenderer = map->rootNode->getComponent<WaterRenderer>();
+		if (waterRenderer)
+			waterRenderer->setDirty();
+		for (auto& mv : browEdit->mapViews)
+			if (mv.map == map)
+				mv.textureGridDirty = true;
 	}
 	if (std::is_same<T, Gat>::value)
 	{

--- a/browedit/actions/CubeTileChangeAction.cpp
+++ b/browedit/actions/CubeTileChangeAction.cpp
@@ -5,6 +5,7 @@
 #include <browedit/BrowEdit.h>
 #include <browedit/MapView.h>
 #include <browedit/components/GndRenderer.h>
+#include <browedit/components/WaterRenderer.h>
 
 CubeTileChangeAction::CubeTileChangeAction(glm::ivec2 tile, Gnd::Cube* cube, int tileUp, int tileFront, int tileSide)
 {
@@ -61,6 +62,9 @@ void CubeTileChangeAction::perform(Map* map, BrowEdit* browEdit)
 			if (mv.map == map)
 				mv.textureGridDirty = true;
 	}
+	auto waterRenderer = map->rootNode->getComponent<WaterRenderer>();
+	if (waterRenderer)
+		waterRenderer->setDirty();
 }
 
 void CubeTileChangeAction::undo(Map* map, BrowEdit* browEdit)
@@ -83,6 +87,9 @@ void CubeTileChangeAction::undo(Map* map, BrowEdit* browEdit)
 			if (mv.map == map)
 				mv.textureGridDirty = true;
 	}
+	auto waterRenderer = map->rootNode->getComponent<WaterRenderer>();
+	if (waterRenderer)
+		waterRenderer->setDirty();
 }
 
 std::string CubeTileChangeAction::str()

--- a/browedit/components/GndRenderer.cpp
+++ b/browedit/components/GndRenderer.cpp
@@ -17,7 +17,6 @@ GndRenderer::GndRenderer()
 	renderContext = GndRenderContext::getInstance();
 
 	white = util::ResourceManager<gl::Texture>::load("data\\texture\\white.png");
-	gndShadow = new gl::Texture(shadowmapSize, shadowmapSize);
 	gndShadowDirty = true;
 }
 
@@ -61,6 +60,11 @@ void GndRenderer::render()
 
 	if (gndShadowDirty)
 	{
+		if (gndShadow == nullptr) {
+			shadowmapSize = glm::max(gnd->width * gnd->lightmapWidth, gnd->height * gnd->lightmapHeight);
+			gndShadow = new gl::Texture(shadowmapSize, shadowmapSize);
+		}
+
 		char* data = new char[shadowmapSize * shadowmapSize * 4];
 		int x = 0; int y = 0;
 		for (size_t i = 0; i < gnd->lightmaps.size(); i++)
@@ -242,7 +246,7 @@ void GndRenderer::Chunk::rebuild()
 	const float lmsxu = lmsx - 2.0f;
 	const float lmsyu = lmsy - 2.0f;
 	
-	const int shadowmapRowCount = shadowmapSize / gnd->lightmapWidth;
+	const int shadowmapRowCount = renderer->shadowmapSize / gnd->lightmapWidth;
 
 	for (int x = this->x; x < glm::min(this->x + CHUNKSIZE, (int)gnd->cubes.size()); x++)
 	{
@@ -258,9 +262,9 @@ void GndRenderer::Chunk::rebuild()
 				
 				if(tile->lightmapIndex >= 0)
 				{
-					lm1 = glm::vec2((tile->lightmapIndex % shadowmapRowCount) * (lmsx / shadowmapSize) + 1.0f / shadowmapSize,
-								  (tile->lightmapIndex / shadowmapRowCount) * (lmsy / shadowmapSize) + 1.0f / shadowmapSize);
-					lm2 = glm::vec2(lm1 + glm::vec2(lmsxu / shadowmapSize, lmsyu / shadowmapSize));
+					lm1 = glm::vec2((tile->lightmapIndex % shadowmapRowCount) * (lmsx / renderer->shadowmapSize) + 1.0f / renderer->shadowmapSize,
+								  (tile->lightmapIndex / shadowmapRowCount) * (lmsy / renderer->shadowmapSize) + 1.0f / renderer->shadowmapSize);
+					lm2 = glm::vec2(lm1 + glm::vec2(lmsxu / renderer->shadowmapSize, lmsyu / renderer->shadowmapSize));
 				}
 
 				glm::vec4 c1(1.0);
@@ -306,8 +310,8 @@ void GndRenderer::Chunk::rebuild()
 				Gnd::Tile* tile = gnd->tiles[cube->tileSide];
 				assert(tile->lightmapIndex >= 0);
 
-				glm::vec2 lm1((tile->lightmapIndex % shadowmapRowCount) * (lmsx / shadowmapSize) + 1.0f / shadowmapSize, (tile->lightmapIndex / shadowmapRowCount) * (lmsy / shadowmapSize) + 1.0f / shadowmapSize);
-				glm::vec2 lm2(lm1 + glm::vec2(lmsxu / shadowmapSize, lmsyu / shadowmapSize));
+				glm::vec2 lm1((tile->lightmapIndex % shadowmapRowCount) * (lmsx / renderer->shadowmapSize) + 1.0f / renderer->shadowmapSize, (tile->lightmapIndex / shadowmapRowCount) * (lmsy / renderer->shadowmapSize) + 1.0f / renderer->shadowmapSize);
+				glm::vec2 lm2(lm1 + glm::vec2(lmsxu / renderer->shadowmapSize, lmsyu / renderer->shadowmapSize));
 
 
 				glm::vec4 c1(1.0f);
@@ -335,8 +339,8 @@ void GndRenderer::Chunk::rebuild()
 				Gnd::Tile* tile = gnd->tiles[cube->tileFront];
 				assert(tile->lightmapIndex >= 0);
 
-				glm::vec2 lm1((tile->lightmapIndex % shadowmapRowCount) * (lmsx / shadowmapSize) + 1.0f / shadowmapSize, (tile->lightmapIndex / shadowmapRowCount) * (lmsy / shadowmapSize) + 1.0f / shadowmapSize);
-				glm::vec2 lm2(lm1 + glm::vec2(lmsxu / shadowmapSize, lmsyu / shadowmapSize));
+				glm::vec2 lm1((tile->lightmapIndex % shadowmapRowCount) * (lmsx / renderer->shadowmapSize) + 1.0f / renderer->shadowmapSize, (tile->lightmapIndex / shadowmapRowCount) * (lmsy / renderer->shadowmapSize) + 1.0f / renderer->shadowmapSize);
+				glm::vec2 lm2(lm1 + glm::vec2(lmsxu / renderer->shadowmapSize, lmsyu / renderer->shadowmapSize));
 
 				glm::vec4 c1(1.0f);
 				if (y < gnd->height - 1 && gnd->cubes[x][y + 1]->tileUp != -1)

--- a/browedit/components/GndRenderer.h
+++ b/browedit/components/GndRenderer.h
@@ -21,7 +21,7 @@ class GndShader;
 class GndRenderer : public Renderer
 {
 public:
-	inline static const int shadowmapSize = 4096;
+	int shadowmapSize;
 
 	class GndRenderContext : public Renderer::RenderContext, public util::Singleton<GndRenderContext>
 	{
@@ -71,7 +71,7 @@ public:
 	Gnd* gnd;
 	Rsw* rsw; //for lighting
 
-	gl::Texture* gndShadow;
+	gl::Texture* gndShadow = nullptr;
 
 	void setChunkDirty(int x, int y);
 	void setChunksDirty();

--- a/browedit/windows/ShadowEditWindow.cpp
+++ b/browedit/windows/ShadowEditWindow.cpp
@@ -1,0 +1,35 @@
+#include <browedit/BrowEdit.h>
+#include <browedit/Icons.h>
+#include <browedit/MapView.h>
+#include <browedit/Map.h>
+#include <browedit/Node.h>
+#include <browedit/components/Rsw.h>
+#include <imgui.h>
+#include <glm/gtc/type_ptr.hpp>
+#include <GLFW/glfw3.h>
+
+bool shadowDropperEnabled = false;
+void BrowEdit::showShadowEditWindow()
+{
+	if (!activeMapView)
+		return;
+	ImGui::Begin("Shadow Edit Window");
+
+	ImGui::SliderInt("Brush Alpha", &shadowEditBrushAlpha, 0, 255);
+
+	if (ImGui::IsKeyPressed(GLFW_KEY_KP_ADD))
+		shadowEditBrushSize++;
+	if (ImGui::IsKeyPressed(GLFW_KEY_KP_SUBTRACT))
+		shadowEditBrushSize = glm::max(shadowEditBrushSize - 1, 1);
+
+	ImGui::InputInt("Brush Size", &shadowEditBrushSize);
+	ImGui::Checkbox("Smooth shadow edges", &shadowSmoothEdges);
+
+	if (toolBarButton("Color Picker", ICON_DROPPER, "Picks a color from the shadowmap", ImVec4(1, 1, 1, 1)))
+	{
+		shadowDropperEnabled = !shadowDropperEnabled;
+		cursor = shadowDropperEnabled ? dropperCursor : nullptr;
+	}
+
+	ImGui::End();
+}

--- a/data/shaders/gnd.fs
+++ b/data/shaders/gnd.fs
@@ -41,7 +41,10 @@ void main()
 	vec3 ambient = lightAmbient - ambientFactor + ambientFactor * lightDiffuse;
 	vec3 diffuseFactor = (1.0 - lightDiffuse) * lightDiffuse;
 	vec3 diffuse = lightDiffuse - diffuseFactor + diffuseFactor * lightAmbient;
-	texture.rgb *= min((NL * diffuse + ambient), 1.0);
+	vec3 mult1 = min(NL * diffuse + ambient, 1.0);
+	// The formula quite literally changes when the combined value of lightAmbient + lightDiffuse is greater than 1.0
+	vec3 mult2 = min(max(lightDiffuse, lightAmbient) + (1.0 - max(lightDiffuse, lightAmbient)) * min(lightDiffuse, lightAmbient), 1.0);
+	texture.rgb *= min(mult1, mult2);
 	texture.rgb *= max(color, colorToggle).rgb;
 	texture.rgb *= max(texture2D(s_lighting, texCoord2).a, shadowMapToggle);
 	texture.rgb += clamp(texture2D(s_lighting, texCoord2).rgb, 0.0, 1.0) * lightColorToggle;

--- a/data/shaders/rsm.fs
+++ b/data/shaders/rsm.fs
@@ -34,13 +34,18 @@ void main()
 		if (shadeType == 4) { // only for editor
 			color.rgb *= lightDiffuse;
 		}
+		else if (shadeType == 0) {
+			color.rgb *= min(max(lightDiffuse, lightAmbient) + (1.0 - max(lightDiffuse, lightAmbient)) * min(lightDiffuse, lightAmbient), 1.0);
+		}
 		else {
-			float NL = shadeType == 0 ? 1.0 : clamp(dot(normalize(normal), lightDirection),0.0,1.0);
+			float NL = clamp(dot(normalize(normal), lightDirection),0.0,1.0);
 			vec3 ambientFactor = (1.0 - lightAmbient) * lightAmbient;
 			vec3 ambient = lightAmbient - ambientFactor + ambientFactor * lightDiffuse;
 			vec3 diffuseFactor = (1.0 - lightDiffuse) * lightDiffuse;
 			vec3 diffuse = lightDiffuse - diffuseFactor + diffuseFactor * lightAmbient;
-			color.rgb *= min((NL * diffuse + ambient), 1.0);
+			vec3 mult1 = min(NL * diffuse + ambient, 1.0);
+			vec3 mult2 = min(max(lightDiffuse, lightAmbient) + (1.0 - max(lightDiffuse, lightAmbient)) * min(lightDiffuse, lightAmbient), 1.0);
+			color.rgb *= min(mult1, mult2);
 		}
 	}
 	


### PR DESCRIPTION
- Added/brought back the shadow edit mode (Gak request).
- Changed the fixed shadowmap size from 4096 to the map size instead (for quicker redrawing of a dirty gnd).
- Small change to the gnd/rsm shaders for lighting, for better accuracy.