### PR TITLE
Copy paste tiles

### DIFF
--- a/browedit/BrowEdit.cpp
+++ b/browedit/BrowEdit.cpp
@@ -832,6 +832,8 @@ void BrowEdit::copyTiles()
 				}
 			}
 	}
+
+	glm::vec3 centerObjects(center.x * 10 - 5 * gnd->width, 0, center.y * 10 - 5 * gnd->height);
 	clipboard["objects"] = json::array();
 	activeMapView->map->rootNode->traverse([&](Node* n) {
 		auto rswObject = n->getComponent<RswObject>();
@@ -844,6 +846,7 @@ void BrowEdit::copyTiles()
 					pos.z >= 10 * gnd->height - (tile.y + 1) * 10 + 10 && pos.z <= 10 * gnd->height - (tile.y + 0) * 10 + 10)
 				{
 					clipboard["objects"].push_back(*n);
+					clipboard["objects"][clipboard["objects"].size() - 1]["relative_position"] = rswObject->position - centerObjects;
 					break;
 				}
 			}

--- a/browedit/MapView.Heightmode.cpp
+++ b/browedit/MapView.Heightmode.cpp
@@ -967,11 +967,11 @@ void MapView::postRenderHeightMode(BrowEdit* browEdit)
 						{
 							auto cube = gnd->cubes[x][y];
 							verts.push_back(VertexP3T2N3(glm::vec3(10 * x, -cube->h3 + dist, 10 * gnd->height - 10 * y), glm::vec2(0), cube->normals[2]));
-							verts.push_back(VertexP3T2N3(glm::vec3(10 * x, -cube->h1 + dist, 10 * gnd->height - 10 * y + 10), glm::vec2(0), cube->normals[0]));
+							verts.push_back(VertexP3T2N3(glm::vec3(10 * x + 10, -cube->h2 + dist, 10 * gnd->height - 10 * y + 10), glm::vec2(0), cube->normals[1]));
 							verts.push_back(VertexP3T2N3(glm::vec3(10 * x + 10, -cube->h4 + dist, 10 * gnd->height - 10 * y), glm::vec2(0), cube->normals[3]));
 
 							verts.push_back(VertexP3T2N3(glm::vec3(10 * x, -cube->h1 + dist, 10 * gnd->height - 10 * y + 10), glm::vec2(0), cube->normals[0]));
-							verts.push_back(VertexP3T2N3(glm::vec3(10 * x + 10, -cube->h4 + dist, 10 * gnd->height - 10 * y), glm::vec2(0), cube->normals[3]));
+							verts.push_back(VertexP3T2N3(glm::vec3(10 * x, -cube->h3 + dist, 10 * gnd->height - 10 * y), glm::vec2(0), cube->normals[2]));
 							verts.push_back(VertexP3T2N3(glm::vec3(10 * x + 10, -cube->h2 + dist, 10 * gnd->height - 10 * y + 10), glm::vec2(0), cube->normals[1]));
 						}
 					}

--- a/browedit/MapView.Heightmode.cpp
+++ b/browedit/MapView.Heightmode.cpp
@@ -197,17 +197,17 @@ void MapView::postRenderHeightMode(BrowEdit* browEdit)
 
 			if ((browEdit->pasteOptions & PasteOptions::Objects) != 0)
 			{
-				auto ga = new GroupAction("Pasting " + std::to_string(browEdit->newNodes.size()) + " objects");
 				bool first = false;
 				glm::ivec2 center(browEdit->pasteData["center"]);
 				glm::ivec2 offset = tileHovered - center;
-
+				glm::vec3 centerObjects(center.x * 10 - 5 * gnd->width, 0, center.y * 10 - 5 * gnd->height);
 
 				for (auto newNode : browEdit->pasteData["objects"])
 				{
 					Node* n = new Node(newNode["name"].get<std::string>());
 					n->addComponentsFromJson(newNode["components"]);
-
+					glm::vec3 relative_position;
+					from_json(newNode["relative_position"], relative_position);
 					std::string path = n->name;
 					if (path.find("\\") != std::string::npos)
 						path = path.substr(0, path.rfind("\\"));
@@ -215,7 +215,7 @@ void MapView::postRenderHeightMode(BrowEdit* browEdit)
 						path = "";
 					n->setParent(map->findAndBuildNode(path));
 					n->makeNameUnique(map->rootNode);
-					n->getComponent<RswObject>()->position += glm::vec3(10 * offset.x, 0, 10 * offset.y);
+					n->getComponent<RswObject>()->position = relative_position + glm::vec3(10 * offset.x, 0, 10 * offset.y) + centerObjects;
 					ga->addAction(new NewObjectAction(n));
 					auto sa = new SelectAction(map, n, first, false);
 					sa->perform(map, browEdit); // to make sure everything is selected

--- a/browedit/Node.cpp
+++ b/browedit/Node.cpp
@@ -2,6 +2,7 @@
 #include "components/Component.h"
 #include "components/Renderer.h"
 #include "components/Collider.h"
+#include "components/LubRenderer.h"
 #include "components/Rsm.h"
 #include <browedit/util/Util.h>
 #include <browedit/util/ResourceManager.h>
@@ -221,6 +222,7 @@ void Node::addComponentsFromJson(const nlohmann::json& data)
 			auto lubEffect = new LubEffect();
 			from_json(c, *lubEffect);
 			this->addComponent(lubEffect);
+			this->addComponent(new LubRenderer());
 		}
 		if (c["type"] == "rswsound")
 		{

--- a/browedit/components/LubRenderer.cpp
+++ b/browedit/components/LubRenderer.cpp
@@ -61,7 +61,7 @@ void LubRenderer::render()
 		else
 			texture = nullptr;
 	}
-	if (!rswObject || !lubEffect)
+	if (!rswObject || !lubEffect || !gnd)
 		return;
 
 	auto shader = dynamic_cast<LubRenderContext*>(renderContext)->shader;//TODO: don't cast

--- a/browedit/components/Rsw.Light.cpp
+++ b/browedit/components/Rsw.Light.cpp
@@ -19,11 +19,8 @@
 void RswLight::load(std::istream* is)
 {
 	auto rswObject = node->getComponent<RswObject>();
-	node->name = util::iso_8859_1_to_utf8(util::FileIO::readString(is, 40));
+	node->name = util::iso_8859_1_to_utf8(util::FileIO::readString(is, 80));
 	is->read(reinterpret_cast<char*>(glm::value_ptr(rswObject->position)), sizeof(float) * 3);
-	rswObject->position *= glm::vec3(1, -1, 1);
-	is->read(reinterpret_cast<char*>(todo), sizeof(float) * 10);
-
 	is->read(reinterpret_cast<char*>(glm::value_ptr(color)), sizeof(float) * 3);
 	is->read(reinterpret_cast<char*>(&range), sizeof(float));
 
@@ -73,11 +70,9 @@ void RswLight::loadExtra(nlohmann::json data)
 void RswLight::save(std::ofstream& file)
 {
 	auto rswObject = node->getComponent<RswObject>();
-	util::FileIO::writeString(file, util::utf8_to_iso_8859_1(node->name), 40);
+	util::FileIO::writeString(file, util::utf8_to_iso_8859_1(node->name), 80);
 
-	file.write(reinterpret_cast<const char*>(glm::value_ptr(rswObject->position * glm::vec3(1, -1, 1))), sizeof(float) * 3);
-	file.write(reinterpret_cast<char*>(todo), sizeof(float) * 10);
-
+	file.write(reinterpret_cast<const char*>(glm::value_ptr(rswObject->position)), sizeof(float) * 3);
 	file.write(reinterpret_cast<char*>(glm::value_ptr(color)), sizeof(float) * 3);
 	file.write(reinterpret_cast<char*>(&range), sizeof(float));
 	//todo: custom light properties

--- a/browedit/components/Rsw.Sound.cpp
+++ b/browedit/components/Rsw.Sound.cpp
@@ -17,17 +17,9 @@ void RswSound::load(std::istream* is, int version)
 
 	node->name = util::iso_8859_1_to_utf8(util::FileIO::readString(is, 80));
 
-	fileName = util::iso_8859_1_to_utf8(util::FileIO::readString(is, 40));
-
-	is->read(reinterpret_cast<char*>(&unknown7), sizeof(float));
-	is->read(reinterpret_cast<char*>(&unknown8), sizeof(float));
-	is->read(reinterpret_cast<char*>(glm::value_ptr(rswObject->rotation)), sizeof(float) * 3);
-	is->read(reinterpret_cast<char*>(glm::value_ptr(rswObject->scale)), sizeof(float) * 3);
-
-	is->read(reinterpret_cast<char*>(unknown6), 8);
+	fileName = util::iso_8859_1_to_utf8(util::FileIO::readString(is, 80));
 
 	is->read(reinterpret_cast<char*>(glm::value_ptr(rswObject->position)), sizeof(float) * 3);
-
 	is->read(reinterpret_cast<char*>(&vol), sizeof(float));
 	is->read(reinterpret_cast<char*>(&width), sizeof(int));
 	is->read(reinterpret_cast<char*>(&height), sizeof(int));
@@ -44,17 +36,9 @@ void RswSound::save(std::ofstream& file, int version)
 	auto rswObject = node->getComponent<RswObject>();
 
 	util::FileIO::writeString(file, util::utf8_to_iso_8859_1(node->name), 80);
-	util::FileIO::writeString(file, util::utf8_to_iso_8859_1(fileName), 40); //TODO: CHECK IF 80/40 or 40/80
-
-	file.write(reinterpret_cast<char*>(&unknown7), sizeof(float));
-	file.write(reinterpret_cast<char*>(&unknown8), sizeof(float));
-	file.write(reinterpret_cast<char*>(glm::value_ptr(rswObject->rotation)), sizeof(float) * 3);
-	file.write(reinterpret_cast<char*>(glm::value_ptr(rswObject->scale)), sizeof(float) * 3);
-
-	file.write(reinterpret_cast<char*>(unknown6), 8);
+	util::FileIO::writeString(file, util::utf8_to_iso_8859_1(fileName), 80);
 
 	file.write(reinterpret_cast<char*>(glm::value_ptr(rswObject->position)), sizeof(float) * 3);
-
 	file.write(reinterpret_cast<char*>(&vol), sizeof(float));
 	file.write(reinterpret_cast<char*>(&width), sizeof(int));
 	file.write(reinterpret_cast<char*>(&height), sizeof(int));
@@ -117,12 +101,6 @@ void RswSound::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& nod
 	util::DragIntMulti<RswSound>(browEdit, browEdit->activeMapView->map, rswSounds, "Height", [](RswSound* s) { return (int*)&s->height; }, 1, 0, 10000); //TODO: remove cast
 	util::DragFloatMulti<RswSound>(browEdit, browEdit->activeMapView->map, rswSounds, "Range", [](RswSound* s) { return &s->range; }, 0.01f, 0.0f, 100.0f);
 	util::DragFloatMulti<RswSound>(browEdit, browEdit->activeMapView->map, rswSounds, "Cycle", [](RswSound* s) { return &s->cycle; }, 0.01f, 0.0f, 100.0f);
-	//no undo for this
-	for(int i = 0; i < 8; i++)
-		util::DragCharMulti<RswSound>(browEdit, browEdit->activeMapView->map, rswSounds, ("Unknown6["+std::to_string(i) + "]").c_str(), [i](RswSound* s) { return (char*)&s->unknown6[i]; }, 1, 0, 255);
-
-	util::DragFloatMulti<RswSound>(browEdit, browEdit->activeMapView->map, rswSounds, "Unknown7", [](RswSound* s) { return &s->unknown7; }, 0.01f, 0.0f, 100.0f);
-	util::DragFloatMulti<RswSound>(browEdit, browEdit->activeMapView->map, rswSounds, "Unknown8", [](RswSound* s) { return &s->unknown8; }, 0.01f, 0.0f, 100.0f);
 }
 
 

--- a/browedit/components/Rsw.h
+++ b/browedit/components/Rsw.h
@@ -206,7 +206,6 @@ public:
 class RswLight : public Component
 {
 public:
-	float todo[10];
 	glm::vec3		color;
 	float			range;
 	// custom properties!!!!!!!!!

--- a/browedit/components/Rsw.h
+++ b/browedit/components/Rsw.h
@@ -308,11 +308,6 @@ public:
 	float	range = 100.0f;
 	float	cycle = 4.0f;
 
-	uint8_t unknown6[8];
-	float unknown7 = -45.0f;
-	float unknown8 = 0.0f;
-
-
 	RswSound() {}
 	RswSound(const std::string &fileName) : fileName(fileName) {}
 	void play();
@@ -320,7 +315,7 @@ public:
 	void save(std::ofstream& file, int version);
 	static void buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>&);
 	
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE(RswSound, fileName, vol, width, height, range, cycle, unknown6, unknown7, unknown8);
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(RswSound, fileName, vol, width, height, range, cycle);
 };
 
 class RswModelCollider : public Collider


### PR DESCRIPTION
Fixed triangle direction when selecting tiles (only applies when selecting the tiles, not when the tiles are selected).
Fixed RswLight reading/saving.
Fixed RswSound reading/saving.
Fixed copy pasting effects missing the LubRenderer node.
Fixed copy pasting objects' relative positions.
Fixed undo/redo with copy pasting objects.