### PR TITLE
Small fixes for lub effects and basic support for 0x207

### DIFF
--- a/BrowEdit3.vcxproj
+++ b/BrowEdit3.vcxproj
@@ -19,6 +19,7 @@
     <ClCompile Include="browedit\actions\GndVersionChangeAction.cpp" />
     <ClCompile Include="browedit\actions\GroupAction.cpp" />
     <ClCompile Include="browedit\actions\LightmapNewAction.cpp" />
+    <ClCompile Include="browedit\actions\LubChangeTextureAction.cpp" />
     <ClCompile Include="browedit\actions\ModelChangeAction.cpp" />
     <ClCompile Include="browedit\actions\NewObjectAction.cpp" />
     <ClCompile Include="browedit\actions\ObjectChangeAction.cpp" />
@@ -144,6 +145,7 @@
     <ClInclude Include="browedit\actions\GndVersionChangeAction.h" />
     <ClInclude Include="browedit\actions\GroupAction.h" />
     <ClInclude Include="browedit\actions\LightmapNewAction.h" />
+    <ClInclude Include="browedit\actions\LubChangeTextureAction.h" />
     <ClInclude Include="browedit\actions\ModelChangeAction.h" />
     <ClInclude Include="browedit\actions\NewObjectAction.h" />
     <ClInclude Include="browedit\actions\ObjectChangeAction.h" />

--- a/BrowEdit3.vcxproj.filters
+++ b/BrowEdit3.vcxproj.filters
@@ -427,6 +427,9 @@
     <ClCompile Include="browedit\actions\LightmapNewAction.cpp">
       <Filter>browedit\actions</Filter>
     </ClCompile>
+    <ClCompile Include="browedit\actions\LubChangeTextureAction.cpp">
+      <Filter>browedit\actions</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\imgui\imgui.h">
@@ -733,6 +736,9 @@
       <Filter>browedit\actions</Filter>
     </ClInclude>
     <ClInclude Include="browedit\actions\LightmapNewAction.h">
+      <Filter>browedit\actions</Filter>
+    </ClInclude>
+    <ClInclude Include="browedit\actions\LubChangeTextureAction.h">
       <Filter>browedit\actions</Filter>
     </ClInclude>
   </ItemGroup>

--- a/browedit/actions/LubChangeTextureAction.cpp
+++ b/browedit/actions/LubChangeTextureAction.cpp
@@ -1,0 +1,1 @@
+#include "LubChangeTextureAction.h"

--- a/browedit/actions/LubChangeTextureAction.h
+++ b/browedit/actions/LubChangeTextureAction.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Action.h"
+#include <browedit/components/Rsw.h>
+#include <browedit/components/RsmRenderer.h>
+#include <browedit/components/GndRenderer.h>
+#include <browedit/components/WaterRenderer.h>
+
+class LubChangeTextureAction : public Action
+{
+	std::string oldValue;
+	std::string newValue;
+	LubEffect* lubEffect;
+public:
+	LubChangeTextureAction(LubEffect *lubEffect, std::string oldValue, std::string newValue)
+	{
+		this->lubEffect = lubEffect;
+		this->oldValue = oldValue;
+		this->newValue = newValue;
+	}
+
+	virtual void perform(Map* map, BrowEdit* browEdit)
+	{
+		this->lubEffect->texture = newValue;
+		this->lubEffect->dirty = true;
+	}
+	virtual void undo(Map* map, BrowEdit* browEdit)
+	{
+		this->lubEffect->texture = oldValue;
+		this->lubEffect->dirty = true;
+	}
+	virtual std::string str()
+	{
+		return "Texture changed to " + newValue;
+	};
+};

--- a/browedit/components/LubRenderer.h
+++ b/browedit/components/LubRenderer.h
@@ -8,6 +8,7 @@ namespace gl { class Texture; }
 class RswObject;
 class Gnd;
 class LubEffect;
+class BillboardRenderer;
 
 class LubRenderer : public Renderer
 {
@@ -26,6 +27,7 @@ public:
 				s_texture,
 				color,
 				billboard_off,
+				selection,
 				End
 			};
 		};
@@ -37,12 +39,14 @@ public:
 			bindUniform(Uniforms::modelMatrix, "modelMatrix");
 			bindUniform(Uniforms::color, "color");
 			bindUniform(Uniforms::billboard_off, "billboard_off");
+			bindUniform(Uniforms::selection, "selection");
 		}
 	};
 private:
 	bool dirty = true;
 	RswObject* rswObject = nullptr;
 	LubEffect* lubEffect = nullptr;
+	BillboardRenderer* billboardRenderer = nullptr;
 
 	gl::Texture* texture = nullptr;
 

--- a/browedit/components/Rsw.Effect.cpp
+++ b/browedit/components/Rsw.Effect.cpp
@@ -11,6 +11,7 @@
 #include <browedit/components/BillboardRenderer.h>
 #include <browedit/actions/AddComponentAction.h>
 #include <browedit/actions/RemoveComponentAction.h>
+#include <browedit/actions/LubChangeTextureAction.h>
 
 #include <iostream>
 #include <fstream>
@@ -180,10 +181,9 @@ void LubEffect::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& no
 		util::DragFloat2Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "rate", [](LubEffect* e) {return &e->rate; }, 0.1f, 0, 0);
 		util::DragFloat2Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "size", [](LubEffect* e) {return &e->size; }, 0.1f, 0, 0);
 		util::DragFloat2Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "life", [](LubEffect* e) {return &e->life; }, 0.1f, 0, 0);
-		if (util::InputTextMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "texture", [](LubEffect* e) {return &e->texture; }))
-		{
-
-		}
+		util::InputTextMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "texture", [](LubEffect* e) {return &e->texture;}, [&](Node* node, std::string* ptr, std::string* startValue, const std::string& action) {
+			browEdit->activeMapView->map->doAction(new LubChangeTextureAction(node->getComponent<LubEffect>(), *startValue, *ptr), browEdit);
+		});
 		util::DragFloatMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "speed", [](LubEffect* e) {return &e->speed; }, 0.1f, 0, 0);
 		util::DragIntMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "srcmode", [](LubEffect* e) {return &e->srcmode; }, 1, 0, 0);
 		util::DragIntMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "destmode", [](LubEffect* e) {return &e->destmode; }, 1, 0, 20);

--- a/browedit/components/Rsw.Model.cpp
+++ b/browedit/components/Rsw.Model.cpp
@@ -27,9 +27,16 @@ void RswModel::load(std::istream* is, int version, unsigned char buildNumber, bo
 		is->read(reinterpret_cast<char*>(&animSpeed), sizeof(float));
 		is->read(reinterpret_cast<char*>(&blockType), sizeof(int));
 	}
-	if (version >= 0x0206 && buildNumber >= 186)
+	if (version >= 0x206 && buildNumber >= 186)
 	{
 		unsigned char c = is->get(); // unknown, 0?
+	}
+
+	if (version >= 0x207)
+	{
+		// Tokei: No idea what this is for
+		int unknown;
+		is->read(reinterpret_cast<char*>(&unknown), sizeof(int));
 	}
 
 	std::string fileNameRaw = util::FileIO::readString(is, 80);
@@ -76,6 +83,13 @@ void RswModel::save(std::ofstream& file, int version, int buildNumber)
 
 		if (version >= 0x206 && buildNumber >= 186) {
 			file.put(0); // ??
+		}
+
+		if (version >= 0x207)
+		{
+			// Tokei: No idea what this is for
+			int unknown = -1;
+			file.write(reinterpret_cast<char*>(&unknown), sizeof(int));
 		}
 	}
 	util::FileIO::writeString(file, util::utf8_to_iso_8859_1(fileName), 80);

--- a/browedit/components/Rsw.cpp
+++ b/browedit/components/Rsw.cpp
@@ -348,6 +348,18 @@ void Rsw::load(const std::string& fileName, Map* map, BrowEdit* browEdit, bool l
 		unknown[1] = unknown[3] = 500;
 	}
 
+	// Tokei: Not sure what this is meant for
+	if (version >= 0x207)
+	{
+		int unknownCount;
+		file->read(reinterpret_cast<char*>(&unknownCount), sizeof(int));
+
+		for (int i = 0; i < unknownCount; i++) {
+			int unknownValue;
+			file->read(reinterpret_cast<char*>(&unknownValue), sizeof(int));
+		}
+	}
+
 	int objectCount;
 	file->read(reinterpret_cast<char*>(&objectCount), sizeof(int));
 	std::cout << "RSW: Loading " << objectCount << " objects" << std::endl;
@@ -547,6 +559,13 @@ void Rsw::save(const std::string& fileName, BrowEdit* browEdit)
 		file.write(reinterpret_cast<char*>(&unknown[1]), sizeof(int));
 		file.write(reinterpret_cast<char*>(&unknown[2]), sizeof(int));
 		file.write(reinterpret_cast<char*>(&unknown[3]), sizeof(int));
+	}
+
+	// Tokei: Not sure what this is meant for; fill it with 0 for now
+	if (version >= 0x207)
+	{
+		int unknownCount = 0;
+		file.write(reinterpret_cast<char*>(&unknownCount), sizeof(int));
 	}
 
 	std::vector<Node*> objects;
@@ -756,6 +775,12 @@ void Rsw::buildImGui(BrowEdit* browEdit)
 			version = 0x0203;
 		if (ImGui::Selectable("0204", version == 0x0204))
 			version = 0x0204;
+		if (ImGui::Selectable("0205", version == 0x0205))
+			version = 0x0205;
+		if (ImGui::Selectable("0206", version == 0x0206))
+			version = 0x0206;
+		if (ImGui::Selectable("0207", version == 0x0207))
+			version = 0x0207;
 		ImGui::EndCombo();
 	}
 	

--- a/browedit/components/Rsw.h
+++ b/browedit/components/Rsw.h
@@ -272,6 +272,7 @@ public:
 	int zenable;
 	int billboard_off;
 	glm::vec3 rotate_angle; // v3
+	bool dirty;
 
 	void load(const nlohmann::json& data);
 	static void buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>&);

--- a/browedit/util/Util.h
+++ b/browedit/util/Util.h
@@ -53,6 +53,9 @@ namespace util
 	bool Checkbox(BrowEdit* browEdit, Map* map, Node* node, const char* label, bool* ptr, const std::string& action = "");
 
 	template<class T>
+	bool InputTextMulti(BrowEdit* browEdit, Map* map, const std::vector<T*>& data, const char* label, const std::function<std::string* (T*)>& getProp, const std::function<void(Node* node, std::string* ptr, std::string* startValue, const std::string& action)>& editAction);
+
+	template<class T>
 	bool InputTextMulti(BrowEdit* browEdit, Map* map, const std::vector<T*>& data, const char* label, const std::function<std::string* (T*)>& getProp);
 
 	template<class T>

--- a/browedit/windows/ObjectSelectWindow.cpp
+++ b/browedit/windows/ObjectSelectWindow.cpp
@@ -7,6 +7,7 @@
 #include <browedit/components/BillboardRenderer.h>
 #include <browedit/components/Rsm.h>
 #include <browedit/components/Rsw.h>
+#include <browedit/components/LubRenderer.h>
 #include <browedit/gl/FBO.h>
 #include <browedit/gl/Texture.h>
 #include <browedit/util/Util.h>
@@ -356,6 +357,29 @@ void BrowEdit::showObjectWindow()
 							newNode->addComponent(e);
 							newNode->addComponent(new BillboardRenderer("data\\effect.png", "data\\effect_selected.png"));
 							newNode->addComponent(new CubeCollider(5));
+							
+							// Tokei: Effect 974 needs to have an LubEffect component attached
+							// This could be made in the json directly, but it will break if the lub effect
+							// properties are changed (which is somewhat often), so it's done in the source instead.
+							if (e->id == 974) {
+								auto lubEffect = new LubEffect();
+								newNode->addComponent(lubEffect);
+								// Add dummy data to show something
+								lubEffect->texture = "smoke2.bmp";
+								lubEffect->gravity = glm::vec3(0, -5, 0);
+								lubEffect->color = glm::vec4(1);
+								lubEffect->rate = glm::vec2(5, 15);
+								lubEffect->size = glm::vec2(3, 8);
+								lubEffect->life = glm::vec2(1, 5);
+								lubEffect->speed = 0.5f;
+								lubEffect->srcmode = 10;
+								lubEffect->destmode = 2;
+								lubEffect->maxcount = 30;
+								lubEffect->zenable = 1;
+
+								newNode->addComponent(new LubRenderer());
+							}
+
 							newNodes.push_back(std::pair<Node*, glm::vec3>(newNode, glm::vec3(0, 0, 0)));
 							newNodesCenter = glm::vec3(0, 0, 0);
 							newNodeHeight = false;

--- a/data/shaders/lub.fs
+++ b/data/shaders/lub.fs
@@ -5,13 +5,18 @@ uniform vec4 color = vec4(1,1,1,1);
 in vec2 texCoord;
 in float alpha;
 out vec4 fragColor;
-
-
+uniform bool selection;
+uniform vec4 selectionColor = vec4(1,1,0.5,0.8f);
 
 void main()
 {
-	vec4 outColor = texture2D(s_texture, texCoord);
-	outColor *= color;
-	outColor.a *= alpha;
-	fragColor = outColor;
+	if (selection) {
+		fragColor = selectionColor;
+	}
+	else {
+		vec4 outColor = texture2D(s_texture, texCoord);
+		outColor *= color;
+		outColor.a *= alpha;
+		fragColor = outColor;
+	}
 }


### PR DESCRIPTION
- Adding a new effect (974) will display a default one instead of having empty fields (so it will show something).
- Editing the texture path of an effect will update it in the editor.
- Added a drawing square around the effect particles when it's selected and holding shift.
- Fixed a bug when editing multi fields and clicking on another field afterward, resulting in the event stack not being in the correct order.
- Added basic support for RSW version 0x207.