### PR TITLE
Lightmap improvements

### DIFF
--- a/BrowEdit3.vcxproj
+++ b/BrowEdit3.vcxproj
@@ -18,6 +18,7 @@
     <ClCompile Include="browedit\actions\GndTextureActions.cpp" />
     <ClCompile Include="browedit\actions\GndVersionChangeAction.cpp" />
     <ClCompile Include="browedit\actions\GroupAction.cpp" />
+    <ClCompile Include="browedit\actions\LightmapChangeAction.cpp" />
     <ClCompile Include="browedit\actions\LightmapNewAction.cpp" />
     <ClCompile Include="browedit\actions\LubChangeTextureAction.cpp" />
     <ClCompile Include="browedit\actions\ModelChangeAction.cpp" />
@@ -144,6 +145,7 @@
     <ClInclude Include="browedit\actions\GndTextureActions.h" />
     <ClInclude Include="browedit\actions\GndVersionChangeAction.h" />
     <ClInclude Include="browedit\actions\GroupAction.h" />
+    <ClInclude Include="browedit\actions\LightmapChangeAction.h" />
     <ClInclude Include="browedit\actions\LightmapNewAction.h" />
     <ClInclude Include="browedit\actions\LubChangeTextureAction.h" />
     <ClInclude Include="browedit\actions\ModelChangeAction.h" />

--- a/BrowEdit3.vcxproj.filters
+++ b/BrowEdit3.vcxproj.filters
@@ -430,6 +430,9 @@
     <ClCompile Include="browedit\actions\LubChangeTextureAction.cpp">
       <Filter>browedit\actions</Filter>
     </ClCompile>
+    <ClCompile Include="browedit\actions\LightmapChangeAction.cpp">
+      <Filter>browedit\actions</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\imgui\imgui.h">
@@ -739,6 +742,9 @@
       <Filter>browedit\actions</Filter>
     </ClInclude>
     <ClInclude Include="browedit\actions\LubChangeTextureAction.h">
+      <Filter>browedit\actions</Filter>
+    </ClInclude>
+    <ClInclude Include="browedit\actions\LightmapChangeAction.h">
       <Filter>browedit\actions</Filter>
     </ClInclude>
   </ItemGroup>

--- a/browedit/BrowEdit.h
+++ b/browedit/BrowEdit.h
@@ -247,7 +247,7 @@ public:
 	} textureBrushMode = TextureBrushMode::Stamp;
 	TextureBrushMode brushModeBeforeDropper;
 
-	bool heightDoodle = true;
+	bool heightDoodle = false;
 
 	std::map<std::string, std::vector<std::string>> tagList; // tag -> [ file ], utf8
 	std::map<std::string, std::vector<std::string>> tagListReverse; // file -> [ tag ], kr
@@ -258,7 +258,11 @@ public:
 	Config config;
 	std::vector<std::pair<Node*, glm::vec3>> newNodes;
 	glm::vec3 newNodesCenter;
-	bool newNodeHeight = false;
+	enum {
+		Ground,		// The new node will be relative to the ground
+		Absolute,	// The new node position will be determined by newNodesCenter
+		Relative	// The new node will be relative to the ground + newNodesCenter
+	} newNodePlacement = Ground;
 	std::vector<CopyCube*> newCubes;
 	std::vector<CopyCubeGat*> newGatCubes;
 	int pasteOptions = -1;

--- a/browedit/HotkeyActions.cpp
+++ b/browedit/HotkeyActions.cpp
@@ -77,7 +77,7 @@ void BrowEdit::registerActions()
 		else if (editMode == EditMode::Gat && !heightDoodle)
 			pasteGat();
 	}, hasActiveMapView);
-	HotkeyRegistry::registerAction(HotkeyAction::Global_PasteChangeHeight,		[this]() { if (editMode == EditMode::Object) { newNodeHeight = !newNodeHeight; } }, hasActiveMapView);
+	HotkeyRegistry::registerAction(HotkeyAction::Global_PasteChangeHeight,		[this]() { if (editMode == EditMode::Object) { newNodePlacement = newNodePlacement == BrowEdit::Absolute ? BrowEdit::Ground : BrowEdit::Absolute; } }, hasActiveMapView);
 
 	HotkeyRegistry::registerAction(HotkeyAction::Global_ClearZeroHeightWalls,	[this]() { activeMapView->map->rootNode->getComponent<Gnd>()->removeZeroHeightWalls(); }, hasActiveMapView);
 	HotkeyRegistry::registerAction(HotkeyAction::Global_CalculateQuadtree,		[this]() { activeMapView->map->recalculateQuadTree(this); }, hasActiveMapView);

--- a/browedit/Lightmapper.h
+++ b/browedit/Lightmapper.h
@@ -10,14 +10,40 @@ class BrowEdit;
 class Gnd;
 class Rsw;
 class Node;
+class RswModel;
+class RswModelCollider;
+class RswObject;
+class RswLight;
 namespace math { class Ray; }
 class Lightmapper
 {
+public:
+	// For faster lookup, since using GetComponent gets slow if there are many models
+	struct light_model {
+		Node* node;
+		RswModel* rswModel;
+		RswModelCollider* collider;
+	};
+
+	struct light_quad_node {
+		std::vector<light_model> models;
+		glm::vec2 range[2];
+	};
+
+	// For faster lookup, since using GetComponent gets slow if there are many lights
+	struct light_data {
+		Node* light;
+		RswObject* rswObject;
+		RswLight* rswLight;
+	};
+
+private:
 	BrowEdit* browEdit;
 	Gnd* gnd;
 	Rsw* rsw;
-	std::vector<Node*> lights;
-	std::vector<Node*> models;
+	std::vector<std::vector<struct Lightmapper::light_quad_node>> quadtree;
+	std::vector<struct Lightmapper::light_data> lights;
+	std::vector<struct Lightmapper::light_model> models;
 	glm::vec3 lightDirection;
 
 	std::thread mainThread;
@@ -32,8 +58,8 @@ private:
 	void run();
 	void onDone();
 
-	bool collidesMap(const math::Ray& ray, float maxDistance);
-	std::pair<glm::vec3, int> calculateLight(const glm::vec3& groundPos, const glm::vec3& normal);
+	bool collidesMap(const math::Ray& ray, int cx, int cy, float maxDistance);
+	std::pair<glm::vec3, int> calculateLight(const glm::vec3& groundPos, const glm::vec3& normal, int cx, int cy);
 	void calcPos(int direction, int tileId, int x, int y);
 
 	void setProgressText(const std::string& text);

--- a/browedit/Map.cpp
+++ b/browedit/Map.cpp
@@ -455,7 +455,7 @@ void Map::pasteSelection(BrowEdit* browEdit)
 			browEdit->newNodesCenter = center;
 			for (auto& n : browEdit->newNodes)
 				n.second = n.second - center;
-			browEdit->newNodeHeight = false;
+			browEdit->newNodePlacement = BrowEdit::Ground;
 		}
 	}
 	catch (...) {

--- a/browedit/MapView.h
+++ b/browedit/MapView.h
@@ -222,6 +222,7 @@ public:
 	bool viewEffectIcons = true;
 
 	bool enableLightQuickPreview = false;
+	bool hideOtherLightmaps = false;
 
 	void focusSelection();
 	void drawLight(Node* n);

--- a/browedit/MapView.h
+++ b/browedit/MapView.h
@@ -109,7 +109,7 @@ public:
 
 	float gadgetOpacity = 0.5f;
 	float gadgetScale = 1.0f;
-	float gadgetThickness = 1.0f;
+	float gadgetThickness = 2.0f;
 
 	int quadTreeMaxLevel = 0;
 
@@ -206,7 +206,7 @@ public:
 	bool viewLightmapColor = true;
 	bool viewColors = true;
 	bool viewLighting = true;
-	bool smoothColors = false;
+	bool smoothColors = true;
 	bool viewTextures = true;
 	bool viewEmptyTiles = true;
 	bool viewGat = false;
@@ -220,6 +220,8 @@ public:
 	bool viewLights = true;
 	bool viewWater = true;
 	bool viewEffectIcons = true;
+
+	bool enableLightQuickPreview = false;
 
 	void focusSelection();
 	void drawLight(Node* n);

--- a/browedit/actions/LightmapChangeAction.cpp
+++ b/browedit/actions/LightmapChangeAction.cpp
@@ -1,0 +1,78 @@
+#include "LightmapChangeAction.h"
+
+#include <browedit/Map.h>
+#include <browedit/Node.h>
+#include <browedit/components/Gnd.h>
+#include <browedit/components/GndRenderer.h>
+
+LightmapChangeAction::LightmapChangeAction()
+{
+}
+
+LightmapChangeAction::~LightmapChangeAction()
+{
+    for (int i = 0; i < m_oldLightmaps.size(); i++)
+        delete m_oldLightmaps[i];
+
+    for (int i = 0; i < m_newLightmaps.size(); i++)
+        delete m_newLightmaps[i];
+}
+
+void LightmapChangeAction::setPreviousData(std::vector<Gnd::Lightmap*> lightmaps, std::vector<Gnd::Tile*> tiles)
+{
+    for (int i = 0; i < lightmaps.size(); i++)
+        m_oldLightmaps.push_back(new Gnd::Lightmap(*lightmaps[i]));
+    for (int i = 0; i < tiles.size(); i++)
+        m_oldLightmapIndex.push_back(tiles[i]->lightmapIndex);
+}
+
+void LightmapChangeAction::setCurrentData(std::vector<Gnd::Lightmap*> lightmaps, std::vector<Gnd::Tile*> tiles)
+{
+    for (int i = 0; i < lightmaps.size(); i++)
+        m_newLightmaps.push_back(new Gnd::Lightmap(*lightmaps[i]));
+    for (int i = 0; i < tiles.size(); i++)
+        m_newLightmapIndex.push_back(tiles[i]->lightmapIndex);
+}
+
+void LightmapChangeAction::perform(Map* map, BrowEdit* browEdit)
+{
+    Gnd* gnd = map->rootNode->getComponent<Gnd>();
+
+    for (int i = 0; i < gnd->lightmaps.size(); i++)
+        delete gnd->lightmaps[i];
+
+    gnd->lightmaps.clear();
+
+    for (int i = 0; i < m_newLightmaps.size(); i++)
+        gnd->lightmaps.push_back(new Gnd::Lightmap(*m_newLightmaps[i]));
+
+    for (int i = 0; i < m_newLightmapIndex.size(); i++)
+        gnd->tiles[i]->lightmapIndex = m_newLightmapIndex[i];
+
+    map->rootNode->getComponent<GndRenderer>()->gndShadowDirty = true;
+    map->rootNode->getComponent<GndRenderer>()->setChunksDirty();
+}
+
+void LightmapChangeAction::undo(Map* map, BrowEdit* browEdit)
+{
+    Gnd* gnd = map->rootNode->getComponent<Gnd>();
+
+    for (int i = 0; i < gnd->lightmaps.size(); i++)
+        delete gnd->lightmaps[i];
+
+    gnd->lightmaps.clear();
+
+    for (int i = 0; i < m_oldLightmaps.size(); i++)
+        gnd->lightmaps.push_back(new Gnd::Lightmap(*m_oldLightmaps[i]));
+
+    for (int i = 0; i < m_oldLightmapIndex.size(); i++)
+        gnd->tiles[i]->lightmapIndex = m_oldLightmapIndex[i];
+
+    map->rootNode->getComponent<GndRenderer>()->gndShadowDirty = true;
+    map->rootNode->getComponent<GndRenderer>()->setChunksDirty();
+}
+
+std::string LightmapChangeAction::str()
+{
+    return "Changed Lightmap";
+}

--- a/browedit/actions/LightmapChangeAction.h
+++ b/browedit/actions/LightmapChangeAction.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Action.h"
+#include <browedit/components/Gnd.h>
+
+class LightmapChangeAction : public Action
+{
+	std::vector<Gnd::Lightmap*> m_oldLightmaps;
+	std::vector<Gnd::Lightmap*> m_newLightmaps;
+	std::vector<int> m_oldLightmapIndex;
+	std::vector<int> m_newLightmapIndex;
+public:
+	LightmapChangeAction();
+	~LightmapChangeAction();
+
+	void setPreviousData(std::vector<Gnd::Lightmap*> lightmaps, std::vector<Gnd::Tile*> tiles);
+	void setCurrentData(std::vector<Gnd::Lightmap*> lightmaps, std::vector<Gnd::Tile*> tiles);
+
+	virtual void perform(Map* map, BrowEdit* browEdit) override;
+	virtual void undo(Map* map, BrowEdit* browEdit) override;
+
+	virtual std::string str() override;
+};

--- a/browedit/components/Gnd.cpp
+++ b/browedit/components/Gnd.cpp
@@ -489,7 +489,181 @@ void Gnd::save(const std::string& fileName, Rsw *rsw)
 	std::cout << "GND: Done saving GND" << std::endl;
 }
 
+glm::vec3 Gnd::rayCastLightmap(const math::Ray& ray, int cx, int cy, int xMin, int yMin, int xMax, int yMax, float rayOffset)
+{
+	if (cubes.size() == 0)
+		return glm::vec3(std::numeric_limits<float>::max());
 
+	if (xMax == -1)
+		xMax = (int)cubes.size();
+	if (yMax == -1)
+		yMax = (int)cubes[0].size();
+
+	xMin = glm::max(0, xMin);
+	yMin = glm::max(0, yMin);
+	xMax = glm::min(xMax, (int)cubes.size());
+	yMax = glm::min(yMax, (int)cubes[0].size());
+
+	float f = 0;
+	
+	// Tokei:
+	// Some explanation for this...
+	// Instead of testing the collision from the ray against every gnd cube, the algorithm below
+	// draws a "2d" line, on the xz coordinate system. The line is the ray we're testing, and we simply 
+	// move along the line until we reach the next gnd cube.
+	// 
+	// For additional optimization, we also check for the Y position every time we hit a new cube.
+	// If the Y position is greater than any of the vertex of the cube (+ walls), then we skip the cube.
+	// The Y position is kept for the next cube check to avoid recalculating the values. This only works
+	// if the Y position goes up on the axis, which is (theoretically) always the case. It is very useful
+	// since maps tend to have many flat cubes and we can skip the majority of them.
+	
+	// line function: y = xz_a * x + xz_b;
+	float xz_a = ray.dir.x == 0 ? 1 : ray.dir.z / ray.dir.x;
+	float xz_b = ray.origin.z - xz_a * ray.origin.x;
+	float xz_ray_length = glm::length(glm::vec2(ray.dir.x, ray.dir.z));
+	float y = 9999999999.0f;
+
+	glm::ivec2 dir(ray.dir.x < 0 ? -1 : (ray.dir.x > 0 ? 1 : 0), ray.dir.z < 0 ? 1 : (ray.dir.z > 0 ? -1 : 0));
+
+	// Cannot collide with another cube directly above itself.
+	if (dir[0] == 0 && dir[1] == 0)
+		return glm::vec3(std::numeric_limits<float>::max());
+
+	// To test collision against the original cube; a tad annoying to handle
+	bool first = true;
+	int cxx, cyy, next_cx = 0;
+
+	while (cx >= xMin && cx < xMax && cy >= yMin && cy < yMax) {
+		if (first) {
+			cxx = cx;
+			cyy = cy;
+		}
+		else {
+			// Z axis only
+			if (ray.dir.x == 0) {
+				next_cx = cx;
+			}
+			else {
+				float next_x;
+
+				if (ray.dir.z > 0)
+					next_x = ((height - cy + 1) * 10.0f - xz_b) / xz_a;
+				else
+					next_x = ((height - cy) * 10.0f - xz_b) / xz_a;
+			
+				next_cx = (int)(next_x / 10);
+			}
+
+			// If we don't move along the X axis, then move along the Z axis.
+			// cxx/cyy is the next cube to check for a collision.
+			cxx = cx + (next_cx != cx ? dir[0] : 0);
+			cyy = cy + (next_cx == cx ? dir[1] : 0);
+
+			if ((cxx == cx && cyy == cy) || cxx < xMin || cxx >= xMax || cyy < yMin || cyy >= yMax)
+				break;
+		}
+
+		Gnd::Cube* cube = cubes[cxx][cyy];
+
+		if ((cube->tileUp != -1 && (ray.dir.y <= 0 || (y >= glm::min(cube->h1, glm::min(cube->h2, glm::min(cube->h3, cube->h4))))))
+			|| (cube->tileSide != -1 && cxx < width - 1 && (ray.dir.y <= 0 || (y >= glm::min(cube->h2, glm::min(cube->h4, glm::min(cubes[cxx + 1][cyy]->h1, cubes[cxx + 1][cyy]->h3))))))
+			|| (cube->tileFront != -1 && cyy < height - 1 && (ray.dir.y <= 0 || (y >= glm::min(cube->h3, glm::min(cube->h4, glm::min(cubes[cxx][cyy + 1]->h2, cubes[cxx][cyy + 1]->h1))))))
+			) {
+			float xx, zz;
+
+			if (!first) {
+				if (next_cx == cx) {
+					zz = (height - cy + 1 + ((dir[1] + 1) >> 1)) * 10.0f;
+					xx = (zz - xz_b) / xz_a;
+				}
+				else {
+					xx = (cx + ((dir[0] + 1) >> 1)) * 10.0f;
+					zz = xz_a * xx + xz_b;
+				}
+
+				y = -ray.dir.y * (glm::length(glm::vec2(xx, zz) - glm::vec2(ray.origin.x, ray.origin.z)) / xz_ray_length) - ray.origin.y;
+			}
+			else {
+				y = -ray.origin.y;
+			}
+		}
+		else {
+			// y value went above the next cube vertices, skip
+			cx = cxx;
+			cy = cyy;
+			first = false;
+			continue;
+		}
+
+		cx = cxx;
+		cy = cyy;
+		first = false;
+
+		if (cube->tileUp != -1 && (ray.dir.y <= 0 || (y >= glm::min(cube->h1, glm::min(cube->h2, glm::min(cube->h3, cube->h4))))))
+		{
+			glm::vec3 v1(10 * cx, -cube->h3, 10 * height - 10 * cy);
+			glm::vec3 v2(10 * cx + 10, -cube->h4, 10 * height - 10 * cy);
+			glm::vec3 v3(10 * cx, -cube->h1, 10 * height - 10 * cy + 10);
+			glm::vec3 v4(10 * cx + 10, -cube->h2, 10 * height - 10 * cy + 10);
+
+			{
+				std::vector<glm::vec3> v{ v4, v2, v1 };
+				if (ray.LineIntersectPolygon(v, f))
+					if (f >= rayOffset)
+						return ray.origin + f * ray.dir;
+			}
+			{
+				std::vector<glm::vec3> v{ v4, v1, v3 };
+				if (ray.LineIntersectPolygon(v, f))
+					if (f >= rayOffset)
+						return ray.origin + f * ray.dir;
+			}
+		}
+		if (cube->tileSide != -1 && cx < width - 1 && (ray.dir.y <= 0 || (y >= glm::min(cube->h2, glm::min(cube->h4, glm::min(cubes[cx + 1][cy]->h1, cubes[cx + 1][cy]->h3))))))
+		{
+			glm::vec3 v1(10 * cx + 10, -cube->h2, 10 * height - 10 * cy + 10);
+			glm::vec3 v2(10 * cx + 10, -cube->h4, 10 * height - 10 * cy);
+			glm::vec3 v3(10 * cx + 10, -cubes[cx + 1][cy]->h1, 10 * height - 10 * cy + 10);
+			glm::vec3 v4(10 * cx + 10, -cubes[cx + 1][cy]->h3, 10 * height - 10 * cy);
+
+			{
+				std::vector<glm::vec3> v{ v4, v2, v1 };
+				if (ray.LineIntersectPolygon(v, f))
+					if (f >= rayOffset)
+						return ray.origin + f * ray.dir;
+			}
+			{
+				std::vector<glm::vec3> v{ v4, v1, v3 };
+				if (ray.LineIntersectPolygon(v, f))
+					if (f >= rayOffset)
+						return ray.origin + f * ray.dir;
+			}
+		}
+		if (cube->tileFront != -1 && cy < height - 1 && (ray.dir.y <= 0 || (y >= glm::min(cube->h3, glm::min(cube->h4, glm::min(cubes[cx][cy + 1]->h2, cubes[cx][cy + 1]->h1))))))
+		{
+			glm::vec3 v1(10 * cx, -cube->h3, 10 * height - 10 * cy);
+			glm::vec3 v2(10 * cx + 10, -cube->h4, 10 * height - 10 * cy);
+			glm::vec3 v4(10 * cx + 10, -cubes[cx][cy + 1]->h2, 10 * height - 10 * cy);
+			glm::vec3 v3(10 * cx, -cubes[cx][cy + 1]->h1, 10 * height - 10 * cy);
+
+			{
+				std::vector<glm::vec3> v{ v4, v2, v1 };
+				if (ray.LineIntersectPolygon(v, f))
+					if (f >= rayOffset)
+						return ray.origin + f * ray.dir;
+			}
+			{
+				std::vector<glm::vec3> v{ v4, v1, v3 };
+				if (ray.LineIntersectPolygon(v, f))
+					if (f >= rayOffset)
+						return ray.origin + f * ray.dir;
+			}
+		}
+	}
+
+	return glm::vec3(std::numeric_limits<float>::max());
+}
 
 glm::vec3 Gnd::rayCast(const math::Ray& ray, bool emptyTiles, int xMin, int yMin, int xMax, int yMax, float rayOffset)
 {
@@ -603,7 +777,7 @@ glm::vec3 Gnd::rayCast(const math::Ray& ray, bool emptyTiles, int xMin, int yMin
 void Gnd::makeLightmapsUnique()
 {
 	makeTilesUnique();
-	cleanLightmaps(); 
+	cleanLightmaps();
 	std::set<int> taken;
 	for (Tile* t : tiles)
 	{
@@ -927,49 +1101,52 @@ void Gnd::makeLightmapBorders(BrowEdit* browEdit)
 	node->getComponent<GndRenderer>()->gndShadowDirty = true;
 }
 
-
 void Gnd::cleanLightmaps()
 {
-	std::cout<< "Lightmap cleanup, starting with " << lightmaps.size() << " lightmaps" <<std::endl;
-	std::map<unsigned char, std::vector<std::size_t>> lookup;
-
+	std::cout << "Lightmap cleanup, starting with " << lightmaps.size() << " lightmaps" << std::endl;
+	
+	std::map<unsigned int, std::vector<int>> light2lightmapIndex;
+	std::map<int, unsigned short> oldIndex2newIndex;
+	std::vector<Lightmap*> newLightmaps;
+	
 	for (int i = 0; i < (int)lightmaps.size(); i++)
 	{
-		unsigned char hash = lightmaps[i]->hash();
+		unsigned int hash = lightmaps[i]->hash();
 		bool found = false;
-		if (lookup.find(hash) != lookup.end())
-		{
-			for (const auto ii : lookup[hash])
-			{
-				if ((*lightmaps[i]) == (*lightmaps[ii]))
-				{// if it is found
-					assert(i > (int)ii);
-					//change all tiles with lightmap i to ii
-					for (auto tile : tiles)
-						if (tile->lightmapIndex == i)
-							tile->lightmapIndex = (unsigned short)ii;
-						else if (tile->lightmapIndex > i)
-							tile->lightmapIndex--;
-					//remove lightmap i
-					delete lightmaps[i];
-					lightmaps.erase(lightmaps.begin() + i);
-					i--;
+	
+		if (light2lightmapIndex.find(hash) != light2lightmapIndex.end()) {
+			for (const auto ii : light2lightmapIndex[hash]) {
+				if ((*lightmaps[i]) == (*lightmaps[ii])) {
+					oldIndex2newIndex[i] = oldIndex2newIndex[ii];
 					found = true;
 					break;
 				}
 			}
 		}
-		if (!found)
-		{
-			lookup[hash].push_back(i);
+	
+		if (!found) {
+			light2lightmapIndex[hash].push_back(i);
+			oldIndex2newIndex[i] = (unsigned short)newLightmaps.size();
+			newLightmaps.push_back(new Lightmap(*lightmaps[i]));
 		}
-
+	}
+	
+	for (int i = 0; i < (int)lightmaps.size(); i++)
+		delete lightmaps[i];
+	
+	lightmaps.clear();
+	
+	for (int i = 0; i < (int)newLightmaps.size(); i++) {
+		lightmaps.push_back(newLightmaps[i]);
+	}
+	
+	for (auto tile : tiles) {
+		tile->lightmapIndex = oldIndex2newIndex[tile->lightmapIndex];
 	}
 
 	std::cout<< "Lightmap cleanup, ending with " << lightmaps.size() << " lightmaps" << std::endl;
 	node->getComponent<GndRenderer>()->setChunksDirty();
 	node->getComponent<GndRenderer>()->gndShadowDirty = true;
-
 }
 
 
@@ -1367,16 +1544,30 @@ std::vector<glm::vec3> Gnd::getMapQuads()
 	return quads;
 }
 
-const unsigned char Gnd::Lightmap::hash() const //actually a crc, but will work
+const unsigned int Gnd::Lightmap::hash() const
 {
 #define POLY 0x82f63b78
-	unsigned char crc = ~0;
-	for (int i = 0; i < gnd->lightmapWidth*gnd->lightmapHeight*4; i++) {
+	const int precision = 8;
+	unsigned int crc = ~0;
+	int size = gnd->lightmapWidth * gnd->lightmapHeight * 4;
+	if (size < 4)
+		return 0;
+	for (int i = 0; i < size; i++) {
 		crc ^= data[i];
-		for (int k = 0; k < 8; k++)
-			crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+		crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
+		//crc += (data[i] ^ POLY) & 0xff;
 	}
 	return ~crc;
+
+	//const int precision = 8;
+	//unsigned long crc = 0;
+	//int size = gnd->lightmapWidth * gnd->lightmapHeight * 4;
+	//if (size < 4)
+	//	return 0;
+	//for (int i = 0; i < precision; i++) {
+	//	crc |= (data[i * size / precision] & 0xf) << (i * precision);
+	//}
+	//return crc;
 }
 
 

--- a/browedit/components/Gnd.cpp
+++ b/browedit/components/Gnd.cpp
@@ -1555,19 +1555,8 @@ const unsigned int Gnd::Lightmap::hash() const
 	for (int i = 0; i < size; i++) {
 		crc ^= data[i];
 		crc = crc & 1 ? (crc >> 1) ^ POLY : crc >> 1;
-		//crc += (data[i] ^ POLY) & 0xff;
 	}
 	return ~crc;
-
-	//const int precision = 8;
-	//unsigned long crc = 0;
-	//int size = gnd->lightmapWidth * gnd->lightmapHeight * 4;
-	//if (size < 4)
-	//	return 0;
-	//for (int i = 0; i < precision; i++) {
-	//	crc |= (data[i * size / precision] & 0xf) << (i * precision);
-	//}
-	//return crc;
 }
 
 

--- a/browedit/components/Gnd.h
+++ b/browedit/components/Gnd.h
@@ -25,6 +25,7 @@ public:
 	~Gnd();
 	void save(const std::string &fileName, Rsw* rsw);
 	glm::vec3 rayCast(const math::Ray& ray, bool emptyTiles = false, int xMin = 0, int yMin = 0, int xMax = -1, int yMax = -1, float offset = 0.0f);
+	glm::vec3 rayCastLightmap(const math::Ray& ray, int cx, int cy, int xMin = 0, int yMin = 0, int xMax = -1, int yMax = -1, float offset = 0.0f);
 	void makeLightmapsUnique();
 	void makeLightmapsClear();
 	void makeLightmapBorders(BrowEdit* browEdit);
@@ -128,7 +129,7 @@ public:
 		unsigned char* data;
 		Gnd* gnd;
 		void expandBorders();
-		const unsigned char hash() const;
+		const unsigned int hash() const;
 		bool operator == (const Lightmap& other) const;
 		LightmapRow operator [] (int x) { return LightmapRow{ this, x }; }
 		friend void to_json(nlohmann::json& nlohmann_json_j, const Lightmap& nlohmann_json_t) {

--- a/browedit/components/GndRenderer.cpp
+++ b/browedit/components/GndRenderer.cpp
@@ -140,6 +140,30 @@ void GndRenderer::render()
 	//shader->setUniform(GndShader::Uniforms::fogExp, rsw->fog.factor);
 	shader->setUniform(GndShader::Uniforms::fogColor, rsw->fog.color);
 
+	if (quickRenderLightNode != nullptr) {
+		auto rswLight = quickRenderLightNode->getComponent<RswLight>();
+		auto rswObject = quickRenderLightNode->getComponent<RswObject>();
+
+		shader->setUniform(GndShader::Uniforms::light_position, glm::vec3(gnd->width * 5.0f + rswObject->position.x, -rswObject->position.y, gnd->height * 5.0f + 10.0f - rswObject->position.z));
+		shader->setUniform(GndShader::Uniforms::light_color, rswLight->color);
+		shader->setUniform(GndShader::Uniforms::lightCount, 1);
+		shader->setUniform(GndShader::Uniforms::light_type, (int)rswLight->lightType);
+		shader->setUniform(GndShader::Uniforms::light_falloff_style, (int)rswLight->falloffStyle);
+		shader->setUniform(GndShader::Uniforms::light_range, rswLight->range);
+		shader->setUniform(GndShader::Uniforms::light_intensity, rswLight->intensity);
+		shader->setUniform(GndShader::Uniforms::light_cutoff, rswLight->cutOff);
+		shader->setUniform(GndShader::Uniforms::light_diffuseLighting, rswLight->diffuseLighting);
+		shader->setUniform(GndShader::Uniforms::light_direction, rswLight->direction);
+		shader->setUniform(GndShader::Uniforms::light_width, rswLight->spotlightWidth);
+		shader->setUniform(GndShader::Uniforms::light_falloff_count, glm::min(10, (int)rswLight->falloff.size()));
+
+		for (int i = 0; i < rswLight->falloff.size() && i < 10; i++) {
+			shader->setUniform(GndShader::Uniforms::light_falloff_0 + i, rswLight->falloff[i]);
+		}
+	}
+	else {
+		shader->setUniform(GndShader::Uniforms::lightCount, 0);
+	}
 
 
 	for (auto r : chunks)

--- a/browedit/components/GndRenderer.cpp
+++ b/browedit/components/GndRenderer.cpp
@@ -144,6 +144,7 @@ void GndRenderer::render()
 		auto rswLight = quickRenderLightNode->getComponent<RswLight>();
 		auto rswObject = quickRenderLightNode->getComponent<RswObject>();
 
+		shader->setUniform(GndShader::Uniforms::hideOtherLights, quickRenderLight_hideOthers);
 		shader->setUniform(GndShader::Uniforms::light_position, glm::vec3(gnd->width * 5.0f + rswObject->position.x, -rswObject->position.y, gnd->height * 5.0f + 10.0f - rswObject->position.z));
 		shader->setUniform(GndShader::Uniforms::light_color, rswLight->color);
 		shader->setUniform(GndShader::Uniforms::lightCount, 1);

--- a/browedit/components/GndRenderer.h
+++ b/browedit/components/GndRenderer.h
@@ -89,6 +89,7 @@ public:
 	bool smoothColors = false;
 	bool viewTextures = true;
 	bool viewFog = true;
+	bool quickRenderLight_hideOthers = false;
 	Node* quickRenderLightNode = nullptr;
 
 	bool viewEmptyTiles = true;

--- a/browedit/components/GndRenderer.h
+++ b/browedit/components/GndRenderer.h
@@ -89,6 +89,7 @@ public:
 	bool smoothColors = false;
 	bool viewTextures = true;
 	bool viewFog = true;
+	Node* quickRenderLightNode = nullptr;
 
 	bool viewEmptyTiles = true;
 };

--- a/browedit/components/Rsw.Light.cpp
+++ b/browedit/components/Rsw.Light.cpp
@@ -183,7 +183,6 @@ void RswLight::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& nod
 	}
 	util::CheckboxMulti<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Enabled", [](RswLight* l) { return &l->enabled; });
 
-	//if (ImGui::Button("Save as template")) {
 	if (ImGui::Checkbox("Quick preview", &browEdit->activeMapView->enableLightQuickPreview)) {
 		if (!browEdit->activeMapView->enableLightQuickPreview) {
 			auto gndRenderer = browEdit->activeMapView->map->rootNode->getComponent<GndRenderer>();
@@ -197,10 +196,15 @@ void RswLight::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& nod
 		auto gndRenderer = browEdit->activeMapView->map->rootNode->getComponent<GndRenderer>();
 
 		if (gndRenderer) {
-			if (browEdit->activeMapView->enableLightQuickPreview)
+			if (browEdit->activeMapView->enableLightQuickPreview) {
 				gndRenderer->quickRenderLightNode = rswLights[0]->node;
+				gndRenderer->quickRenderLight_hideOthers = browEdit->activeMapView->hideOtherLightmaps;
+			}
 		}
 	}
+
+	ImGui::SameLine();
+	ImGui::Checkbox("Hide other lightmaps", &browEdit->activeMapView->hideOtherLightmaps);
 
 	util::ColorEdit3Multi<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Color", [](RswLight* l) { return &l->color; });
 	if(rswLights.front()->lightType != RswLight::Type::Sun)

--- a/browedit/components/Rsw.Light.cpp
+++ b/browedit/components/Rsw.Light.cpp
@@ -2,6 +2,8 @@
 #include "Rsw.h"
 #include <browedit/BrowEdit.h>
 #include <browedit/Node.h>
+#include <browedit/components/GndRenderer.h>
+#include <browedit/Map.h>
 #include <browedit/util/FileIO.h>
 #include <browedit/util/Util.h>
 
@@ -181,6 +183,25 @@ void RswLight::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& nod
 	}
 	util::CheckboxMulti<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Enabled", [](RswLight* l) { return &l->enabled; });
 
+	//if (ImGui::Button("Save as template")) {
+	if (ImGui::Checkbox("Quick preview", &browEdit->activeMapView->enableLightQuickPreview)) {
+		if (!browEdit->activeMapView->enableLightQuickPreview) {
+			auto gndRenderer = browEdit->activeMapView->map->rootNode->getComponent<GndRenderer>();
+			
+			if (gndRenderer)
+				gndRenderer->quickRenderLightNode = nullptr;
+		}
+	}
+
+	if (browEdit->activeMapView->enableLightQuickPreview) {
+		auto gndRenderer = browEdit->activeMapView->map->rootNode->getComponent<GndRenderer>();
+
+		if (gndRenderer) {
+			if (browEdit->activeMapView->enableLightQuickPreview)
+				gndRenderer->quickRenderLightNode = rswLights[0]->node;
+		}
+	}
+
 	util::ColorEdit3Multi<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Color", [](RswLight* l) { return &l->color; });
 	if(rswLights.front()->lightType != RswLight::Type::Sun)
 		util::DragFloatMulti<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Range", [](RswLight* l) { return &l->range; }, 1.0f, 0.0f, 1000.0f);
@@ -208,7 +229,7 @@ void RswLight::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& nod
 	}
 	if (rswLights.front()->lightType != RswLight::Type::Sun)
 	{
-		util::ComboBoxMulti<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Falloff style", "exponential\0spline tweak\0lagrange tweak\0linear tweak\0magic\0", [](RswLight* l) { return (int*) & l->falloffStyle; });
+		util::ComboBoxMulti<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Falloff style", "exponential\0spline tweak\0lagrange tweak\0linear tweak\0magic\0s curve\0", [](RswLight* l) { return (int*) & l->falloffStyle; });
 
 		differentValues = !std::all_of(rswLights.begin(), rswLights.end(), [&](RswLight* o) { return o->falloffStyle == rswLights.front()->falloffStyle; });
 		if (!differentValues)
@@ -226,6 +247,8 @@ void RswLight::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& nod
 				util::EditableGraphMulti<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Light Falloff", [](RswLight* l) {return &l->falloff; }, util::interpolateLagrange);
 			else if (falloffStyle == FalloffStyle::LinearTweak)
 				util::EditableGraphMulti<RswLight>(browEdit, browEdit->activeMapView->map, rswLights, "Light Falloff", [](RswLight* l) {return &l->falloff; }, util::interpolateLinear);
+			else if (falloffStyle == FalloffStyle::S_Curve)
+				util::Graph("Light Falloff", [&](float x) { return util::interpolateSCurve(x) / 2.0f; });
 			else if (falloffStyle == FalloffStyle::Exponential)
 			{
 				bool differentFalloff = !std::all_of(rswLights.begin(), rswLights.end(), [&](RswLight* o) { return o->falloffStyle == rswLights.front()->falloffStyle; });

--- a/browedit/components/Rsw.h
+++ b/browedit/components/Rsw.h
@@ -133,6 +133,7 @@ public:
 		int quality = 1;
 		bool shadows = true;
 		bool heightSelectionOnly = false;
+		bool additiveShadow = true;
 		glm::ivec2 rangeX;
 		glm::ivec2 rangeY;
 
@@ -216,10 +217,11 @@ public:
 		Spot,
 		Sun
 	} lightType = Type::Point;
-	bool givesShadow = true;
-	bool affectShadowMap = true;
+	bool givesShadow = false;
+	bool affectShadowMap = false;
 	bool affectLightmap = true;
 	bool enabled = true;
+	bool quickPreview = true;
 	bool shadowTerrain = true;
 
 	bool sunMatchRswDirection = true;
@@ -233,8 +235,9 @@ public:
 		LagrangeTweak = 2,
 		LinearTweak = 3,
 		Magic = 4,
+		S_Curve = 5,
 	};
-	FalloffStyle falloffStyle = FalloffStyle::Exponential;
+	FalloffStyle falloffStyle = FalloffStyle::S_Curve;
 
 	float cutOff = 0.5f;
 	float intensity = 1;
@@ -249,7 +252,7 @@ public:
 	void save(std::ofstream& file);
 	nlohmann::json saveExtra();
 	static void buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>&);
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE(RswLight, color, enabled, lightType, spotlightWidth, sunMatchRswDirection, direction, range, givesShadow, cutOff, cutOff, intensity, affectShadowMap, affectLightmap, falloff, falloffStyle, shadowTerrain);
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(RswLight, color, enabled, lightType, spotlightWidth, sunMatchRswDirection, direction, range, givesShadow, cutOff, cutOff, intensity, minShadowDistance, affectShadowMap, affectLightmap, falloff, falloffStyle, shadowTerrain, diffuseLighting);
 };
 
 class LubEffect : public Component
@@ -321,6 +324,7 @@ public:
 
 class RswModelCollider : public Collider
 {
+	std::vector<std::vector<std::vector<glm::vec3>>> buffered_faces;
 	RswModel* rswModel = nullptr;
 	Rsm* rsm = nullptr;
 	RsmRenderer* rsmRenderer = nullptr;
@@ -328,6 +332,8 @@ public:
 	void begin();
 	bool collidesTexture(const math::Ray& ray, float minDistance = 0.0f, float maxDistance = 9999999.0f);
 	bool collidesTexture(Rsm::Mesh* mesh, const math::Ray& ray, const glm::mat4& matrix, float minDistance, float maxDistance);
+	void calculateWorldFaces(Rsm::Mesh* mesh, const glm::mat4& matrix);
+	void calculateWorldFaces();
 
 	std::vector<glm::vec3> getVerticesWorldSpace(Rsm::Mesh* mesh = nullptr, const glm::mat4& matrix = glm::mat4(1.0f));
 	std::vector<glm::vec3> getAllVerticesWorldSpace(Rsm::Mesh* mesh = nullptr, const glm::mat4& matrix = glm::mat4(1.0f));

--- a/browedit/components/Rsw.h
+++ b/browedit/components/Rsw.h
@@ -221,7 +221,6 @@ public:
 	bool affectShadowMap = false;
 	bool affectLightmap = true;
 	bool enabled = true;
-	bool quickPreview = true;
 	bool shadowTerrain = true;
 
 	bool sunMatchRswDirection = true;

--- a/browedit/gl/Shader.h
+++ b/browedit/gl/Shader.h
@@ -9,9 +9,10 @@ namespace gl
 	class Shader
 	{
 		std::string file;
-		GLuint programId;
 		int* uniforms;
 	public:
+		GLuint programId;
+
 		Shader(const std::string& file, int end);
 		~Shader();
 		void setUniform(int name, bool value);

--- a/browedit/shaders/GndShader.h
+++ b/browedit/shaders/GndShader.h
@@ -49,6 +49,7 @@ public:
 			light_falloff_8,
 			light_falloff_9,
 			light_falloff_count,
+			hideOtherLights,
 			End
 		};
 	};
@@ -94,5 +95,6 @@ public:
 		bindUniform(Uniforms::light_falloff_8, "lights[0].falloff[8]");
 		bindUniform(Uniforms::light_falloff_9, "lights[0].falloff[9]");
 		bindUniform(Uniforms::light_falloff_count, "lights[0].falloff_count");
+		bindUniform(Uniforms::hideOtherLights, "hideOtherLights");
 	}
 };

--- a/browedit/shaders/GndShader.h
+++ b/browedit/shaders/GndShader.h
@@ -27,6 +27,28 @@ public:
 			fogNear,
 			fogFar,
 			//fogExp,
+			lightCount,
+			light_position,
+			light_color,
+			light_type,
+			light_falloff_style,
+			light_range,
+			light_intensity,
+			light_cutoff,
+			light_diffuseLighting,
+			light_direction,
+			light_width,
+			light_falloff_0,
+			light_falloff_1,
+			light_falloff_2,
+			light_falloff_3,
+			light_falloff_4,
+			light_falloff_5,
+			light_falloff_6,
+			light_falloff_7,
+			light_falloff_8,
+			light_falloff_9,
+			light_falloff_count,
 			End
 		};
 	};
@@ -50,5 +72,27 @@ public:
 		bindUniform(Uniforms::fogNear, "fogNear");
 		bindUniform(Uniforms::fogFar, "fogFar");
 		//bindUniform(Uniforms::fogExp, "fogExp");
+		bindUniform(Uniforms::lightCount, "lightCount");
+		bindUniform(Uniforms::light_position, "lights[0].position");
+		bindUniform(Uniforms::light_color, "lights[0].color");
+		bindUniform(Uniforms::light_type, "lights[0].type");
+		bindUniform(Uniforms::light_falloff_style, "lights[0].falloff_style");
+		bindUniform(Uniforms::light_range, "lights[0].range");
+		bindUniform(Uniforms::light_intensity, "lights[0].intensity");
+		bindUniform(Uniforms::light_cutoff, "lights[0].cutoff");
+		bindUniform(Uniforms::light_diffuseLighting, "lights[0].diffuseLighting");
+		bindUniform(Uniforms::light_direction, "lights[0].direction");
+		bindUniform(Uniforms::light_width, "lights[0].width");
+		bindUniform(Uniforms::light_falloff_0, "lights[0].falloff[0]");
+		bindUniform(Uniforms::light_falloff_1, "lights[0].falloff[1]");
+		bindUniform(Uniforms::light_falloff_2, "lights[0].falloff[2]");
+		bindUniform(Uniforms::light_falloff_3, "lights[0].falloff[3]");
+		bindUniform(Uniforms::light_falloff_4, "lights[0].falloff[4]");
+		bindUniform(Uniforms::light_falloff_5, "lights[0].falloff[5]");
+		bindUniform(Uniforms::light_falloff_6, "lights[0].falloff[6]");
+		bindUniform(Uniforms::light_falloff_7, "lights[0].falloff[7]");
+		bindUniform(Uniforms::light_falloff_8, "lights[0].falloff[8]");
+		bindUniform(Uniforms::light_falloff_9, "lights[0].falloff[9]");
+		bindUniform(Uniforms::light_falloff_count, "lights[0].falloff_count");
 	}
 };

--- a/browedit/util/Util.cpp
+++ b/browedit/util/Util.cpp
@@ -1434,6 +1434,21 @@ namespace util
 		float diff = (x - before.x) / (after.x - before.x);
 		return before.y + diff * (after.y - before.y);
 	}
+	float interpolateSCurve(float x) {
+		// Alright, this isn't an S Curve formula anymore, but your typical light attenuation formula... but with the shape of an S Curve.
+		x = 2 * x - 1;
+		const float a = 1.5f;
+		const float b = 1.5f;
+
+		if (x <= -1)
+			return 2;
+		if (x >= 1)
+			return 0;
+		if (x <= 0)
+			return -1.0f / (1.0f + a * -x + b * x * x) * (1.0f + x) + 2;
+
+		return 1.0f / (1.0f + a * x + b * x * x) * (1.0f - x);
+	}
 
 	bool EditableGraph(const char* label, std::vector<glm::vec2>* points, std::function<float(const std::vector<glm::vec2>&, float)> interpolationStyle, bool& activated)
 	{

--- a/browedit/util/Util.h
+++ b/browedit/util/Util.h
@@ -92,6 +92,7 @@ namespace util
 	float interpolateLagrange(const std::vector<glm::vec2>& f, float x);
 	float interpolateSpline(const std::vector<glm::vec2>& f, float x);
 	float interpolateLinear(const std::vector<glm::vec2>& f, float x);
+	float interpolateSCurve(float x);
 	bool EditableGraph(const char* label, std::vector<glm::vec2>* points, std::function<float(const std::vector<glm::vec2>&, float)> interpolationStyle, bool& activated);
 	void Graph(const char* label, std::function<float(float)> func);
 

--- a/browedit/windows/LightmapSettingsWindow.cpp
+++ b/browedit/windows/LightmapSettingsWindow.cpp
@@ -25,6 +25,7 @@ void BrowEdit::showLightmapSettingsWindow()
 		ImGui::Checkbox("Shadows", &settings.shadows);
 		ImGui::Checkbox("Debug Points", &lightmapper->buildDebugPoints);
 		ImGui::Checkbox("Height Edit Mode Selection Only", &settings.heightSelectionOnly);
+		ImGui::Checkbox("Old shadow formula (v3.561 and below)", &settings.additiveShadow);
 		ImGui::DragInt2("Generate Range X", glm::value_ptr(settings.rangeX), 1, 0, gnd->width);
 		ImGui::DragInt2("Generate Range Y", glm::value_ptr(settings.rangeY), 1, 0, gnd->height);
 		ImGui::DragInt("Thread Count", &config.lightmapperThreadCount, 1, 1, 32);

--- a/browedit/windows/ObjectSelectWindow.cpp
+++ b/browedit/windows/ObjectSelectWindow.cpp
@@ -325,7 +325,7 @@ void BrowEdit::showObjectWindow()
 							newNode->addComponent(new RswModelCollider());
 							newNodes.push_back(std::pair<Node*, glm::vec3>(newNode, glm::vec3(0, 0, 0)));
 							newNodesCenter = glm::vec3(0, 0, 0);
-							newNodeHeight = false;
+							newNodePlacement = BrowEdit::Ground;
 						}
 						else if (file.substr(file.size() - 5) == ".json" &&
 							path.find("data\\lights") != std::string::npos)
@@ -342,7 +342,7 @@ void BrowEdit::showObjectWindow()
 							newNode->addComponent(new CubeCollider(5));
 							newNodes.push_back(std::pair<Node*, glm::vec3>(newNode, glm::vec3(0, 0, 0)));
 							newNodesCenter = glm::vec3(0, 0, 0);
-							newNodeHeight = false;
+							newNodePlacement = BrowEdit::Ground;
 						}
 						else if (file.substr(file.size() - 5) == ".json" &&
 							path.find("data\\effects") != std::string::npos)
@@ -382,7 +382,7 @@ void BrowEdit::showObjectWindow()
 
 							newNodes.push_back(std::pair<Node*, glm::vec3>(newNode, glm::vec3(0, 0, 0)));
 							newNodesCenter = glm::vec3(0, 0, 0);
-							newNodeHeight = false;
+							newNodePlacement = BrowEdit::Ground;
 						}
 						else if (file.substr(file.size() - 5) == ".json" &&
 							path.find("data\\prefabs") != std::string::npos)
@@ -455,7 +455,7 @@ void BrowEdit::showObjectWindow()
 								newNodesCenter = center;
 								for (auto& n : newNodes)
 									n.second = n.second - center;
-								newNodeHeight = false;
+								newNodePlacement = BrowEdit::Ground;
 							}
 						}
 						else if (file.substr(file.size() - 4) == ".wav")
@@ -468,7 +468,7 @@ void BrowEdit::showObjectWindow()
 							newNode->addComponent(new CubeCollider(5));
 							newNodes.push_back(std::pair<Node*, glm::vec3>(newNode, glm::vec3(0, 0, 0)));
 							newNodesCenter = glm::vec3(0, 0, 0);
-							newNodeHeight = false;
+							newNodePlacement = BrowEdit::Ground;
 						}
 					}
 					std::cout << "Click on " << file << std::endl;

--- a/data/shaders/gnd.fs
+++ b/data/shaders/gnd.fs
@@ -12,6 +12,7 @@ uniform float colorToggle = 1.0f;
 uniform float lightColorToggle = 1.0f;
 uniform float shadowMapToggle = 1.0f;
 uniform float viewTextures = 1.0f;
+uniform int lightCount = 0;
 
 uniform bool fogEnabled;
 uniform float fogNear = 0;
@@ -25,7 +26,29 @@ in vec3 normal;
 in vec4 color;
 
 out vec4 fragColor;
-//out vec4 fragSelection;
+in vec3 fragPos;
+
+#define MAX_FALLOFF 10
+#define NR_LIGHTS 1
+
+struct Light {
+    vec3 position;
+    vec3 color;
+	int type;
+	int falloff_style;
+	vec2 falloff[MAX_FALLOFF];
+	int falloff_count;
+	float range;
+	float intensity;
+	float cutoff;
+	bool diffuseLighting;
+	vec3 direction;
+	float width;
+};
+
+uniform Light lights[NR_LIGHTS];
+
+vec3 CalcPointLight(Light light, vec3 normal, vec3 inFragPos);
 
 void main()
 {
@@ -49,14 +72,173 @@ void main()
 	texture.rgb *= max(texture2D(s_lighting, texCoord2).a, shadowMapToggle);
 	texture.rgb += clamp(texture2D(s_lighting, texCoord2).rgb, 0.0, 1.0) * lightColorToggle;
 
+    for (int i = 0; i < lightCount; i++)
+        texture.rgb += CalcPointLight(lights[i], normalize(normal), fragPos);   
+
 	if(fogEnabled)
 	{
 		float depth = gl_FragCoord.z / gl_FragCoord.w;
 		float fogAmount = smoothstep(fogNear, fogFar, depth);
 		texture = mix(texture, fogColor, fogAmount);
 	}	
-
-	//gl_FragData[0] = texture;
-	//gl_FragData[1] = vec4(0,0,0,0);
+	
 	fragColor = texture;
+}
+
+// calculates the color when using a point light.
+vec3 CalcPointLight(Light light, vec3 normal, vec3 inFragPos)
+{
+	normal = vec3(normal.x, -normal.y, normal.z);
+	vec3 lightDir = normalize(light.position - inFragPos);
+    float distance = length(light.position - inFragPos);
+	
+	if (light.type == 2)	// sun, ignored
+		return vec3(0, 0, 0);
+	
+	float attenuation = 0.0f;
+	float dotProduct = abs(dot(normalize(normal), lightDir));
+	
+	if (light.falloff_style == 4) {
+		float kC = 1;
+		float kL = 2.0f / light.range;
+		float kQ = 1.0f / (light.range * light.range);
+		float maxChannel = max(max(light.color.r, light.color.g), light.color.b);
+		float realRange = (-kL + sqrt(kL * kL - 4 * kQ * (kC - 128.0f * maxChannel * light.intensity))) / (2 * kQ);
+		
+		if (distance > realRange)
+			return vec3(0, 0, 0);
+		
+		float d = max(distance - light.range, 0.0f);
+		float denom = d / light.range + 1;
+		attenuation = light.intensity / (denom * denom);
+		if (light.cutoff > 0)
+			attenuation = max(0.0f, (attenuation - light.cutoff) / (1 - light.cutoff));
+	}
+	else {
+		if (distance > light.range)
+			return vec3(0, 0, 0);
+		
+		float d = distance / light.range;
+		
+		if (light.falloff_style == 0) {
+			attenuation = clamp(1.0f - pow(d, light.cutoff), 0.0f, 1.0f);
+		}
+		else if (light.falloff_style == 1) {	// Spline
+			int n = light.falloff_count;
+			float h[MAX_FALLOFF];
+			float F[MAX_FALLOFF];
+			float s[MAX_FALLOFF];
+			float m[MAX_FALLOFF * MAX_FALLOFF];
+			
+			for (int i = n - 1; i > 0; i--) {
+				h[i] = 0.0f;
+				F[i] = 0.0f;
+				s[i] = 0.0f;
+			}
+			
+			for (int i = n - 1; i > 0; i--)
+			{
+				F[i] = (light.falloff[i].y - light.falloff[i - 1].y) / (light.falloff[i].x - light.falloff[i - 1].x);
+				h[i - 1] = light.falloff[i].x - light.falloff[i - 1].x;
+			}
+			
+			for (int i = 1; i < n - 1; i++)
+			{
+				m[i * MAX_FALLOFF + i] = 2 * (h[i - 1] + h[i]);
+				if (i != 1)
+				{
+					m[i * MAX_FALLOFF + i - 1] = h[i - 1];
+					m[(i - 1) * MAX_FALLOFF + i] = h[i - 1];
+				}
+				m[i * MAX_FALLOFF + n - 1] = 6 * (F[i + 1] - F[i]);
+			}
+			
+			for (int i = 1; i < n - 2; i++)
+			{
+				float temp = (m[(i + 1) * MAX_FALLOFF + i] / m[i * MAX_FALLOFF + i]);
+				for (int j = 1; j <= n - 1; j++)
+					m[(i + 1) * MAX_FALLOFF + j] -= temp * m[i * MAX_FALLOFF + j];
+			}
+			float sum;
+			for (int i = n - 2; i > 0; i--)
+			{
+				sum = 0;
+				for (int j = i; j <= n - 2; j++)
+					sum += m[i * MAX_FALLOFF + j] * s[j];
+				s[i] = (m[i * MAX_FALLOFF + n - 1] - sum) / m[i * MAX_FALLOFF + i];
+			}
+			for (int i = 0; i < n - 1; i++) {
+				if (light.falloff[i].x <= d && d <= light.falloff[i + 1].x)
+				{
+					float a = (s[i + 1] - s[i]) / (6 * h[i]);
+					float b = s[i] / 2;
+					float c = (light.falloff[i + 1].y - light.falloff[i].y) / h[i] - (2 * h[i] * s[i] + s[i + 1] * h[i]) / 6;
+					float e = light.falloff[i].y;
+					sum = a * pow((d - light.falloff[i].x), 3.0f) + b * pow((d - light.falloff[i].x), 2.0f) + c * (d - light.falloff[i].x) + e;
+				}
+			}
+			attenuation = clamp(sum, 0.0f, 1.0f);
+		}
+		else if (light.falloff_style == 2) {	// Lagrange
+			for (int i = 0; i < light.falloff_count; i++) {
+				float term = light.falloff[i].y;
+				
+				for (int j = 1; j < light.falloff_count; j++) {
+					if (j != i)
+						term = term * (d - light.falloff[j].x) / (light.falloff[i].x - light.falloff[j].x);
+				}
+				
+				attenuation += term;
+			}
+			
+			attenuation = clamp(attenuation, 0.0f, 1.0f);
+		}
+		else if (light.falloff_style == 3) {	// Linear
+			vec2 before = vec2(-9999, -9999);
+			vec2 after = vec2(9999, 9999);
+			
+			for (int i = 0; i < light.falloff_count; i++) {
+				vec2 p = light.falloff[i];
+				
+				if (p.x <= d && d - p.x < d - before.x)
+					before = p;
+				if (p.x >= d && p.x - d < after.x - d)
+					after = p;
+			}
+			
+			float diff = (d - before.x) / (after.x - before.x);
+			attenuation = before.y + diff * (after.y - before.y);
+			attenuation = clamp(attenuation, 0.0f, 1.0f);
+		}
+		else if (light.falloff_style == 5) {	// S Curve
+			d = 2.0f * d - 1.0f;
+			
+			if (d <= 0.0f)
+				attenuation = -1.0f / (1.0f + 1.5f * - d + 1.5f * d * d) * (1.0f + d) + 2.0f;
+			else
+				attenuation = 1.0f / (1.0f + 1.5f * d + 1.5f * d * d) * (1.0f - d);
+		}
+		else {
+			attenuation = 0.0f;
+		}
+	}
+	
+	if (light.type == 1) {	// spot
+		float dp = dot(lightDir, -light.direction);
+		
+		if (dp < (1 - light.width))
+			attenuation = 0.0f;
+		else {
+			float fac = 1.0f - ((1.0f - abs(dp)) / light.width);
+			attenuation *= fac;
+		}
+	}
+	
+	if (light.diffuseLighting) {
+		attenuation *= dotProduct;
+	}
+	
+	attenuation *= light.intensity;
+	
+	return light.color * attenuation;
 }

--- a/data/shaders/gnd.vs
+++ b/data/shaders/gnd.vs
@@ -13,6 +13,7 @@ out vec2 texCoord;
 out vec2 texCoord2;
 out vec3 normal;
 out vec4 color;
+out vec3 fragPos;
 
 void main()
 {
@@ -20,5 +21,6 @@ void main()
 	texCoord2 = a_texture2;
 	normal = a_normal;
 	color = a_color;
+	fragPos = a_position;
 	gl_Position = projectionMatrix * modelViewMatrix * vec4(a_position,1);
 }


### PR DESCRIPTION
Added undo/redo after calculating lightmaps.
Changed default colormap option to smooth.
Added a 'Quick preview' option when selecting a light. This option renders the light (except the sun) using the shader for instant result. It's not perfect, but it can be a big help when picking a light setting.
Optimized the lightmap calculations, expected to be 10~20 times faster.
Changed the shadow calculation from an additive model to a negative model (can be changed, by default it will use the previous formula to avoid compatibily issues).
Changed the default light settings when opening official maps:
 - The falloff style was changed to a new function 'S Curve' instead of linear. This produces better result to official lights (still not 100% accurate though).
 - The lights will have the shadow options turned off.

Added a new 'Light Edit' menu for the Edit Mode.
Fixed Magic falloff style formula.
Fixed the sun direction if matching the RSW settings.
When moving a light, it will now keep its current height relative to the ground rather than sticking to the ground.