### PR TITLE
Improve error logging

### DIFF
--- a/BrowEdit3.manifest
+++ b/BrowEdit3.manifest
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity
+        type="win32"
+        name="borf.BrowEdit3"
+        version="3.0.0.0"
+        processorArchitecture="*"
+    />
+    <description>BrowEdit 3</description>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 and Windows 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+        </application>
+    </compatibility>
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <asmv3:application>
+    <asmv3:windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <!-- <ws2:longPathAware>true</ws2:longPathAware> -->
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/BrowEdit3.vcxproj
+++ b/BrowEdit3.vcxproj
@@ -81,6 +81,7 @@
     <ClCompile Include="browedit\ModelEditor.cpp" />
     <ClCompile Include="browedit\Node.cpp" />
     <ClCompile Include="browedit\NodeRenderer.cpp" />
+    <ClCompile Include="browedit\util\Console.cpp" />
     <ClCompile Include="browedit\util\FileIO.cpp" />
     <ClCompile Include="browedit\util\Util.cpp" />
     <ClCompile Include="browedit\windows\CinematicModeWindow.cpp" />
@@ -204,6 +205,7 @@
     <ClInclude Include="browedit\shaders\RsmShader.h" />
     <ClInclude Include="browedit\shaders\SimpleShader.h" />
     <ClInclude Include="browedit\shaders\WaterShader.h" />
+    <ClInclude Include="browedit\util\Console.h" />
     <ClInclude Include="browedit\util\FileIO.h" />
     <ClInclude Include="browedit\util\glfw_keycodes_to_string.h" />
     <ClInclude Include="browedit\util\ResourceManager.h" />
@@ -270,6 +272,9 @@
     <None Include="docs\Lightmapping.md" />
     <None Include="docs\ObjectEdit.md" />
     <None Include="docs\Readme.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="BrowEdit3.manifest" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/BrowEdit3.vcxproj
+++ b/BrowEdit3.vcxproj
@@ -314,7 +314,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NOMINMAX;GRF_STATIC;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;VC_EXTRALEAN;NOMINMAX;GRF_STATIC;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>lib/imgui/;lib/glfw-3.3.8/include;lib/grflib;lib/zlib;lib/sfl;lib/glm;lib/glad/include;$(SolutionDir);lib/bugtrap;lib/magic_enum/include;lib/imGuIZMO.quat/imGuIZMO.quat</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -340,7 +340,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NOMINMAX;GRF_STATIC;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;VC_EXTRALEAN;NOMINMAX;GRF_STATIC;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>lib/imgui/;lib/glfw-3.3.8/include;lib/grflib;lib/zlib;lib/sfl;lib/glm;lib/glad/include;$(SolutionDir);lib/bugtrap;lib/magic_enum/include;lib/imGuIZMO.quat/imGuIZMO.quat</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/BrowEdit3.vcxproj.filters
+++ b/BrowEdit3.vcxproj.filters
@@ -433,6 +433,9 @@
     <ClCompile Include="browedit\actions\LightmapChangeAction.cpp">
       <Filter>browedit\actions</Filter>
     </ClCompile>
+    <ClCompile Include="browedit\util\Console.cpp">
+      <Filter>browedit\util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\imgui\imgui.h">
@@ -747,6 +750,9 @@
     <ClInclude Include="browedit\actions\LightmapChangeAction.h">
       <Filter>browedit\actions</Filter>
     </ClInclude>
+    <ClInclude Include="browedit\util\Console.h">
+      <Filter>browedit\util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="BrowEdit3.rc">
@@ -820,5 +826,10 @@
     <None Include="docs\formats\Gnd.md">
       <Filter>docs\formats</Filter>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="BrowEdit3.manifest">
+      <Filter>Resource Files</Filter>
+    </Manifest>
   </ItemGroup>
 </Project>

--- a/browedit/BrowEdit.cpp
+++ b/browedit/BrowEdit.cpp
@@ -1,4 +1,3 @@
-#include <Windows.h> //to remove ugly warning :(
 #include "BrowEdit.h"
 #include "Version.h"
 #include <GLFW/glfw3.h>
@@ -36,8 +35,10 @@
 
 
 #ifdef _WIN32
-extern "C" __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-extern "C" __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
+	#include <Windows.h> //to remove ugly warning :(
+
+	extern "C" __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	extern "C" __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
 #endif
 
 #ifndef _DEBUG
@@ -54,7 +55,6 @@ static void SetupExceptionHandler()
 	BT_SetFlags(BTF_DETAILEDMODE | BTF_SCREENCAPTURE);
 	BT_SetSupportURL("https://discord.gg/bQaj5dKtbV");
 }
-
 
 int main()
 {
@@ -99,6 +99,7 @@ int main()
 
 
 )V0G0N" << std::endl;
+
 	BrowEdit().run();
 }
 

--- a/browedit/BrowEdit.cpp
+++ b/browedit/BrowEdit.cpp
@@ -27,6 +27,7 @@
 #include <browedit/components/RsmRenderer.h>
 #include <browedit/util/FileIO.h>
 #include <browedit/util/Util.h>
+#include <browedit/util/Console.h>
 #include <browedit/util/ResourceManager.h>
 #include <browedit/util/glfw_keycodes_to_string.h>
 
@@ -61,6 +62,8 @@ int main()
 #ifndef _DEBUG
 	SetupExceptionHandler();
 #endif
+
+	ConsoleInject consoleInjector;
 
 	std::cout << R"V0G0N(                                  ';cllllllc:,                                  
                                 ,lodddddddddddoc,                               
@@ -1019,65 +1022,71 @@ void BrowEdit::ShowNewMapPopup()
 
 void fixEffectPreviews()
 {
-	for (auto entry : std::filesystem::directory_iterator("data\\texture\\effect"))
+	try
 	{
-		if (entry.path().string().find(".png") != std::string::npos)
-			continue;
-		if (entry.path().string().find(".gif") == std::string::npos)
-			continue;
-		std::istream* is = util::FileIO::open(entry.path().string());
-		std::cout << entry.path().string() << std::endl;
-		if (!is)
+		for (auto entry : std::filesystem::directory_iterator("data\\texture\\effect", std::filesystem::directory_options::follow_directory_symlink | std::filesystem::directory_options::skip_permission_denied))
 		{
-			std::cerr << "Texture: Could not open " <<entry.path().string() << std::endl;
-			return;
-		}
-		is->seekg(0, std::ios_base::end);
-		std::size_t len = is->tellg();
-		if (len <= 0 || len > 100 * 1024 * 1024)
-		{
-			std::cerr << "Texture: Error opening texture " << entry.path().string() << ", file is either empty or too large" << std::endl;
-			delete is;
-			return;
-		}
-		char* buffer = new char[len];
-		is->seekg(0, std::ios_base::beg);
-		is->read(buffer, len);
-		delete is;
-
-		int width, height, frameCount, comp;
-		int* delays;
-		auto data = stbi_load_gif_from_memory((stbi_uc*)buffer, (int)len, &delays, &width, &height, &frameCount, &comp, 4);
-		if (!data)
-			continue;
-		int bestFrame = 0;
-		int bestFrameCount = 0;
-		for (int f = 0; f < frameCount; f++)
-		{
-			auto d = data + (width * height * 4) * f;
-			int frameIntensity = 0;
-			for (int x = 0; x < width; x++)
+			if (entry.path().string().find(".png") != std::string::npos)
+				continue;
+			if (entry.path().string().find(".gif") == std::string::npos)
+				continue;
+			std::istream* is = util::FileIO::open(entry.path().string());
+			std::cout << entry.path().string() << std::endl;
+			if (!is)
 			{
-				for (int y = 0; y < height; y++)
+				std::cerr << "Texture: Could not open " <<entry.path().string() << std::endl;
+				return;
+			}
+			is->seekg(0, std::ios_base::end);
+			std::size_t len = is->tellg();
+			if (len <= 0 || len > 100 * 1024 * 1024)
+			{
+				std::cerr << "Texture: Error opening texture " << entry.path().string() << ", file is either empty or too large" << std::endl;
+				delete is;
+				return;
+			}
+			char* buffer = new char[len];
+			is->seekg(0, std::ios_base::beg);
+			is->read(buffer, len);
+			delete is;
+
+			int width, height, frameCount, comp;
+			int* delays;
+			auto data = stbi_load_gif_from_memory((stbi_uc*)buffer, (int)len, &delays, &width, &height, &frameCount, &comp, 4);
+			if (!data)
+				continue;
+			int bestFrame = 0;
+			int bestFrameCount = 0;
+			for (int f = 0; f < frameCount; f++)
+			{
+				auto d = data + (width * height * 4) * f;
+				int frameIntensity = 0;
+				for (int x = 0; x < width; x++)
 				{
-					frameIntensity += d[(x + width * y) * 4 + 0];
-					frameIntensity += d[(x + width * y) * 4 + 1];
-					frameIntensity += d[(x + width * y) * 4 + 2];
+					for (int y = 0; y < height; y++)
+					{
+						frameIntensity += d[(x + width * y) * 4 + 0];
+						frameIntensity += d[(x + width * y) * 4 + 1];
+						frameIntensity += d[(x + width * y) * 4 + 2];
+					}
+				}
+				if (frameIntensity > bestFrameCount)
+				{
+					bestFrameCount = frameIntensity;
+					bestFrame = f;
 				}
 			}
-			if (frameIntensity > bestFrameCount)
-			{
-				bestFrameCount = frameIntensity;
-				bestFrame = f;
-			}
+			stbi_write_png((entry.path().string() + ".png").c_str(), width, height, 4, data + bestFrame * width * height*4, 0);
+
+			std::cout << "Best frame is " << bestFrame << std::endl;
+
+
+			stbi_image_free(data);
 		}
-		stbi_write_png((entry.path().string() + ".png").c_str(), width, height, 4, data + bestFrame * width * height*4, 0);
-
-		std::cout << "Best frame is " << bestFrame << std::endl;
-
-
-		stbi_image_free(data);
+		std::cout << "Done" << std::endl;
 	}
-	std::cout << "Done" << std::endl;
-
+	catch (const std::system_error& exception)
+	{
+		std::cerr << "data\\texture\\effect: " << exception.what() << " (" << exception.code() << ")" << std::endl;
+	}
 }

--- a/browedit/BrowEdit.glfw.cpp
+++ b/browedit/BrowEdit.glfw.cpp
@@ -1,7 +1,6 @@
 #include "BrowEdit.h"
 
 #include <iostream>
-#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <Version.h>
 #include <browedit/Image.h>

--- a/browedit/BrowEdit.h
+++ b/browedit/BrowEdit.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <Windows.h>
 #include "Config.h"
 #include "MapView.h"
 #include <json.hpp>

--- a/browedit/components/Rsw.Sound.cpp
+++ b/browedit/components/Rsw.Sound.cpp
@@ -1,4 +1,7 @@
-#include <windows.h>
+#ifdef _WIN32
+	#include <windows.h>
+	#include <mmsystem.h>
+#endif
 #include "Rsw.h"
 #include <browedit/BrowEdit.h>
 #include <browedit/Node.h>

--- a/browedit/components/Rsw.cpp
+++ b/browedit/components/Rsw.cpp
@@ -1,5 +1,6 @@
-#include <Windows.h>
-#include <glad/glad.h>
+#ifdef _WIN32
+	#include <Windows.h>
+#endif
 #include "Rsw.h"
 #include "Gnd.h"
 #include "Gat.h"

--- a/browedit/util/Console.cpp
+++ b/browedit/util/Console.cpp
@@ -1,0 +1,144 @@
+#include "Console.h"
+#include <iostream>
+#include <VersionHelpers.h>
+
+ConsoleInject::ConsoleInject() :
+	#ifdef _WIN32
+		#ifdef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+			ansiEscape(IsWindows10OrGreater()),
+		#else
+			ansiEscape(false),
+		#endif
+
+		errorHandle(nullptr),
+
+		consoleInputCP(CP_NONE),
+		consoleOutputCP(CP_NONE),
+	#else
+		ansiEscape(true),
+	#endif
+	errorSink(ansiEscape)
+{
+	#ifdef _WIN32
+		errorHandle = GetStdHandle(STD_ERROR_HANDLE);
+
+		consoleInputCP = GetConsoleCP();
+		consoleOutputCP = GetConsoleOutputCP();
+
+		SetConsoleCP(CP_UTF8);
+		SetConsoleOutputCP(CP_UTF8);
+
+		if (ansiEscape)
+		{
+			#ifdef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+				DWORD mode = 0;
+				/*
+				auto input = GetStdHandle(STD_INPUT_HANDLE);
+				GetConsoleMode(input, &mode);
+				SetConsoleMode(input, mode | ENABLE_VIRTUAL_TERMINAL_INPUT);
+				*/
+
+				auto output = GetStdHandle(STD_OUTPUT_HANDLE);
+				GetConsoleMode(output, &mode);
+				SetConsoleMode(output, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+
+				GetConsoleMode(errorHandle, &mode);
+				SetConsoleMode(errorHandle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+			#else
+				// ToDo: check for ANSICON
+				// #error ANSI escape sequences are only supported on Windows 10+, please install ANSICON (ANSI.sys)
+			#endif
+		}
+	#endif
+}
+
+ConsoleInject::~ConsoleInject()
+{
+	#ifdef _WIN32
+		SetConsoleCP(consoleInputCP);
+		SetConsoleOutputCP(consoleOutputCP);
+	#endif
+}
+
+ConsoleInject::Sink::Sink(bool ansiEscape) :
+	ansiEscape(ansiEscape),
+	newLine(true),
+
+	sink(),
+
+	#ifdef _WIN32
+		consoleAttributes(0),
+		consoleForgroundMask(FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY),
+		consoleBackgroundMask(BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_INTENSITY)
+	#endif
+{
+	#ifdef _WIN32
+		errorHandle = GetStdHandle(STD_ERROR_HANDLE);
+		CONSOLE_SCREEN_BUFFER_INFO info = {};
+		GetConsoleScreenBufferInfo(errorHandle, &info);
+
+		consoleAttributes = info.wAttributes;
+	#endif
+}
+
+ConsoleInject::ErrorSink::ErrorSink(bool ansiEscape) : Sink(ansiEscape)
+{
+	sink = std::cerr.rdbuf(this);
+}
+
+ConsoleInject::ErrorSink::~ErrorSink()
+{
+	std::cerr.rdbuf(sink);
+}
+
+auto ConsoleInject::ErrorSink::overflow(int_type ch) -> int_type
+{
+	if (traits_type::eq_int_type( ch, traits_type::eof()))
+		return sink->pubsync() == -1 ? ch : traits_type::not_eof(ch);
+
+	if (newLine)
+	{
+		if (ansiEscape)
+		{
+			std::ostream str(sink);
+
+			if (!(str << "\x1b[31;1m"))
+				return traits_type::eof();
+		}
+		else
+		{
+			#ifdef _WIN32
+				auto attributes = consoleAttributes & ~(consoleForgroundMask | consoleBackgroundMask);
+				SetConsoleTextAttribute(errorHandle, attributes | FOREGROUND_RED | FOREGROUND_INTENSITY);
+			#endif
+		}
+	}
+
+	newLine = traits_type::to_char_type(ch) == '\n';
+
+	if (newLine)
+	{
+		if (ansiEscape)
+		{
+			std::ostream str(sink);
+
+			if (!(str << "\x1b[0m"))
+				return traits_type::eof();
+		}
+		else
+		{
+			#ifdef _WIN32
+				SetConsoleTextAttribute(errorHandle, consoleAttributes);
+			#endif
+		}
+	}
+
+	auto out = sink->sputc(ch);
+	if (out == traits_type::eof())
+	{
+		// ToDo: fix up unknown characters
+		return sink->sputc('_');
+	}
+
+	return out;
+}

--- a/browedit/util/Console.h
+++ b/browedit/util/Console.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <ios>
+#ifdef _WIN32
+	#include <Windows.h>
+#endif
+
+class ConsoleInject
+{
+	public:
+		ConsoleInject(const ConsoleInject&) = delete;
+		ConsoleInject& operator=(const ConsoleInject&) = delete;
+
+		ConsoleInject();
+		~ConsoleInject();
+
+	private:
+		class Sink : public std::streambuf
+		{
+			public:
+				Sink(bool ansiEscape);
+
+			protected:
+				bool ansiEscape;
+				bool newLine;
+
+				std::streambuf* sink;
+
+				#ifdef _WIN32
+					HANDLE errorHandle;
+
+					WORD consoleAttributes;
+					WORD consoleForgroundMask;
+					WORD consoleBackgroundMask;
+				#endif
+		};
+
+		class ErrorSink : public Sink
+		{
+			public:
+				ErrorSink(bool ansiEscape);
+				~ErrorSink();
+
+			protected:
+				int_type overflow(int_type ch = traits_type::eof()) override;
+		};
+
+		bool ansiEscape;
+
+		ErrorSink errorSink;
+
+		#ifdef _WIN32
+			HANDLE errorHandle;
+
+			int consoleInputCP;
+			int consoleOutputCP;
+		#endif
+};

--- a/browedit/util/FileIO.cpp
+++ b/browedit/util/FileIO.cpp
@@ -294,10 +294,12 @@ namespace util
 
 	void FileIO::DirSource::listFiles(const std::string& dir, std::vector<std::string>& files)
 	{
-		try {
+		try
+		{
 			if (!std::filesystem::exists(directory + dir))
 				return;
-			for (const auto& entry : std::filesystem::directory_iterator(directory + dir))
+
+			for (const auto& entry : std::filesystem::directory_iterator(directory + dir, std::filesystem::directory_options::follow_directory_symlink | std::filesystem::directory_options::skip_permission_denied))
 			{
 				auto f = entry.path().string();
 				if (f.size() > directory.size() && directory.size() > 0 && f.find(directory) == 0)
@@ -310,9 +312,9 @@ namespace util
 					files.push_back(f);
 			}
 		}
-		catch (...)
+		catch (const std::system_error& exception)
 		{
-			std::cerr << "Something went wrong with listing files" << std::endl;
+			std::cerr << directory + dir << ": " << exception.what() << " (" << exception.code() << ")" << std::endl;
 		}
 	}
 

--- a/browedit/util/Util.cpp
+++ b/browedit/util/Util.cpp
@@ -1,11 +1,8 @@
-#define IMGUI_DEFINE_MATH_OPERATORS
-#include <Windows.h>
-#include <direct.h>
-#include <commdlg.h>
 #include "Util.h"
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/norm.hpp>
+#define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui.h>
 #include <misc/cpp/imgui_stdlib.h>
 #include <imgui_internal.h>
@@ -21,10 +18,20 @@
 #include <browedit/gl/Texture.h>
 
 #ifdef WIN32
-#include <DbgHelp.h>
-#pragma comment(lib,"dbghelp.lib")
-#endif
+	#include <Windows.h>
+	#include <direct.h>
+	#include <commdlg.h>
 
+	#include <DbgHelp.h>
+	#pragma comment(lib,"dbghelp.lib")
+
+	#define GLFW_EXPOSE_NATIVE_WIN32
+	#define GLFW_NATIVE_INCLUDE_NONE
+#endif
+#include <GLFW/glfw3native.h>
+
+// The hacks are continuing
+extern BrowEdit* browEdit;
 
 namespace util
 {
@@ -1675,7 +1682,6 @@ namespace util
 		char curdir[100];
 		_getcwd(curdir, 100);
 
-		HWND hWnd = nullptr;
 		char buf[256];
 		ZeroMemory(&buf, sizeof(buf));
 		strcpy_s(buf, 256, defaultFilename.c_str());
@@ -1683,7 +1689,7 @@ namespace util
 		OPENFILENAME ofn;
 		ZeroMemory(&ofn, sizeof(ofn));
 		ofn.lStructSize = sizeof(ofn);
-		ofn.hwndOwner = hWnd;
+		ofn.hwndOwner = glfwGetWin32Window(browEdit->window);
 		ofn.lpstrFile = buf;
 		ofn.nMaxFile = 1024;
 		ofn.lpstrFilter = filter;
@@ -1710,11 +1716,11 @@ namespace util
 		
 		char curdir[100];
 		_getcwd(curdir, 100);
-		HWND hWnd = nullptr;
+
 		OPENFILENAME ofn;
 		ZeroMemory(&ofn, sizeof(ofn));
 		ofn.lStructSize = sizeof(ofn);
-		ofn.hwndOwner = hWnd;
+		ofn.hwndOwner = glfwGetWin32Window(browEdit->window);
 		ofn.lpstrFile = fileName;
 		ofn.nMaxFile = 1024;
 		ofn.lpstrFilter = filter;
@@ -1745,15 +1751,15 @@ namespace util
 		}
 		return 0;
 	}
-	std::string SelectPathDialog(std::string path)
+	std::string SelectPathDialog(std::string path, std::string title)
 	{
 		CoInitializeEx(0, 0);
 		CHAR szDir[MAX_PATH];
 		BROWSEINFO bInfo;
-		bInfo.hwndOwner = nullptr;// glfwGetWin32Window(browEdit->window);
+		bInfo.hwndOwner = glfwGetWin32Window(browEdit->window);
 		bInfo.pidlRoot = NULL;
 		bInfo.pszDisplayName = szDir;
-		bInfo.lpszTitle = "Select your RO directory (not data)";
+		bInfo.lpszTitle = title.c_str();
 		bInfo.ulFlags = 0;
 		bInfo.lpfn = BrowseCallBackProc;
 		if (path.find(":") == std::string::npos)

--- a/browedit/util/Util.h
+++ b/browedit/util/Util.h
@@ -41,7 +41,7 @@ namespace util
 
 	std::string SaveAsDialog(const std::string& fileName, const char* filter = "All\0*.*\0");
 	std::string SelectFileDialog(std::string defaultFilename, const char* filter = "All\0*.*\0");
-	std::string SelectPathDialog(std::string path);
+	std::string SelectPathDialog(std::string path, std::string title = "Select your RO directory (not data)");
 
 	bool ColorEdit3(BrowEdit* browEdit, Map* map, Node* node, const char* label, glm::vec3* ptr, const std::string& action = "");
 	bool ColorEdit4(BrowEdit* browEdit, Map* map, Node* node, const char* label, glm::vec4* ptr, const std::string& action = "");

--- a/browedit/windows/HelpWindow.cpp
+++ b/browedit/windows/HelpWindow.cpp
@@ -1,4 +1,7 @@
-#include <Windows.h>
+#ifdef _WIN32
+    #include <Windows.h>
+    #include <shellapi.h>
+#endif
 #include <browedit/BrowEdit.h>
 #include <browedit/util/FileIO.h>
 #include <browedit/util/ResourceManager.h>

--- a/browedit/windows/ObjectSelectWindow.cpp
+++ b/browedit/windows/ObjectSelectWindow.cpp
@@ -1,4 +1,7 @@
-#include <windows.h>
+#ifdef _WIN32
+	#include <windows.h>
+	#include <mmsystem.h>
+#endif
 #include <browedit/BrowEdit.h>
 #include <browedit/Node.h>
 #include <browedit/MapView.h>


### PR DESCRIPTION
Highlight any error sent trough `std::cerr` in bight red to the console instead of it vanishing among all the other messages.

As ANSI escape codes are only available since Win10 (the exact build is irrelevant imo) there is a check via `IsWindows10OrGreater()`,
which is available since Windows 2000, I assume we don't have to provide a fallback here? (I know a certain one still using Win98, so...)
There ***is*** a fallback using WIN32 API in case escape codes aren't available, so it shouldn't cause a visual difference there at least.

I also included a commented out `long path awareness` (win10+) setting to the manifest, as I expect this to be handled sooner or later,
so whoever ends up doing it doesn't need to look up how to tell windows about it.

As a bonus, in a separate commit, I've cleaned up some things that reduce compile time a bit and should remove a few warnings about `APIENTRY`,
but some of those go pretty deep into the include chain, and I didn't want to spend too much time there...
It also replaces the manual use of WIN32 API in the config with the functions already set up in `util`, for less maintenance cost.

I tried to align the code style to the existing code as much as I could,
but given that the style vastly differs from what I usually write, and since there are no helpers like `.editorconfig` I may have missed a few spots,
so feel free to go nitpicky on it.