### PR TITLE
Potential fix for the rsm shader not compiling

### DIFF
--- a/data/shaders/rsm.fs
+++ b/data/shaders/rsm.fs
@@ -6,7 +6,7 @@ uniform vec3 lightDirection;
 //uniform float lightIntensity;
 
 uniform int shadeType;
-uniform float discardAlphaValue = 0.8;
+uniform float discardAlphaValue;
 uniform float selection;
 uniform bool lightToggle;
 uniform bool viewTextures;


### PR DESCRIPTION
Removed initialization for the discardAlphaValue property, it is always set in the source anyway.