### PR TITLE
Lightmap and other fixes

### DIFF
--- a/browedit/Image.cpp
+++ b/browedit/Image.cpp
@@ -51,10 +51,10 @@ float Image::get(const glm::vec2& uv)
 	if (!data || !hasAlpha)
 		return 1;
 
-	int x1 = (int)floor(uv.x * width);
-	int y1 = (int)floor(uv.y * height);
-	int x2 = (int)ceil(uv.x * width);
-	int y2 = (int)ceil(uv.y * height);
+	int x1 = glm::min(width - 1, (int)floor(uv.x * width));
+	int y1 = glm::min(height - 1, (int)floor(uv.y * height));
+	int x2 = glm::min(width - 1, (int)ceil(uv.x * width));
+	int y2 = glm::min(height - 1, (int)ceil(uv.y * height));
 
 #if 1
 	float fracX = glm::fract(uv.x * width);

--- a/browedit/Lightmapper.cpp
+++ b/browedit/Lightmapper.cpp
@@ -372,6 +372,7 @@ std::pair<glm::vec3, int> Lightmapper::calculateLight(const glm::vec3& groundPos
 		else if (rswLight->lightType == RswLight::Type::Sun)
 		{
 			attenuation = 255;
+			distance = 99999;
 		}
 
 		bool collides = false;
@@ -421,7 +422,7 @@ std::pair<glm::vec3, int> Lightmapper::calculateLight(const glm::vec3& groundPos
 				// Check if the ray collides with the model
 				for(auto n : quadtree_models) {
 					if (collides && shadowStrength >= 1)
-						continue;
+						break;
 
 					if (n->collider->collidesTexture(ray, 0, distance - rswLight->minShadowDistance))
 					{

--- a/browedit/MapView.cpp
+++ b/browedit/MapView.cpp
@@ -547,7 +547,9 @@ void MapView::render(BrowEdit* browEdit)
 							matrix = glm::scale(matrix, glm::vec3(1, -1, 1));
 						}
 					}
+
 					rsmRenderer->matrixCache = matrix;
+					rsmRenderer->reverseCullFace = false;
 
 					if (rswObject->scale.x * rswObject->scale.y * rswObject->scale.z * (rsm->version >= 0x202 ? -1 : 1) < 0)
 						rsmRenderer->reverseCullFace = true;

--- a/browedit/components/LubRenderer.cpp
+++ b/browedit/components/LubRenderer.cpp
@@ -59,7 +59,7 @@ void LubRenderer::render()
 
 		if (lubEffect && lubEffect->texture != "")
 		{
-			texture = util::ResourceManager<gl::Texture>::load("data\\texture\\" + lubEffect->texture);
+			texture = util::ResourceManager<gl::Texture>::load("data\\texture\\" + util::replace(lubEffect->texture, "\\\\", "\\"));
 		}
 		else
 			texture = nullptr;

--- a/browedit/components/RsmRenderer.cpp
+++ b/browedit/components/RsmRenderer.cpp
@@ -136,6 +136,8 @@ void RsmRenderer::render()
 			}
 		}
 
+		reverseCullFace = false;
+
 		if (rswObject->scale.x * rswObject->scale.y * rswObject->scale.z * (rsm->version >= 0x202 ? -1 : 1) < 0)
 			reverseCullFace = true;
 	}

--- a/browedit/components/Rsw.Effect.cpp
+++ b/browedit/components/Rsw.Effect.cpp
@@ -114,7 +114,7 @@ void LubEffect::load(const json& data)
 	from_json(data["rate"], rate);
 	from_json(data["size"], size);
 	from_json(data["life"], life);
-	texture = data["texture"];
+	texture = util::replace(data["texture"], "\\\\", "\\");
 	speed = data["speed"][0];
 	srcmode = data["srcmode"][0];
 	destmode = data["destmode"][0];

--- a/browedit/components/Rsw.cpp
+++ b/browedit/components/Rsw.cpp
@@ -1221,8 +1221,8 @@ bool RswModelCollider::collidesTexture(Rsm::Mesh* mesh, const math::Ray& ray, co
 			if (rsmMesh)
 			{
 				auto rsm = dynamic_cast<Rsm*>(rsmMesh->model);
-				if (rsm && rsm->textures.size() > mesh->faces[i].texId)
-					img = util::ResourceManager<Image>::load("data/texture/" + rsm->textures[mesh->faces[i].texId]);
+				if (rsm && mesh->faces[i].texId < rsm->textures.size() && mesh->textures[mesh->faces[i].texId] < rsm->textures.size())
+					img = util::ResourceManager<Image>::load("data/texture/" + rsm->textures[mesh->textures[mesh->faces[i].texId]]);
 			}
 			glm::vec3 hitPoint = ray.origin + ray.dir * t;
 			if (img && img->hasAlpha)

--- a/browedit/components/Rsw.cpp
+++ b/browedit/components/Rsw.cpp
@@ -644,7 +644,7 @@ void Rsw::save(const std::string& fileName, BrowEdit* browEdit)
 			SAVEPROP2("rate", lubEffects[i]->rate) << "," << std::endl;
 			SAVEPROP2("size", lubEffects[i]->size) << "," << std::endl;
 			SAVEPROP2("life", lubEffects[i]->life) << "," << std::endl;
-			SAVEPROPS("texture", lubEffects[i]->texture) << "," << std::endl;
+			SAVEPROPS("texture", util::replace(util::replace(lubEffects[i]->texture, "\\\\", "\\"), "\\", "\\\\")) << "," << std::endl;
 			SAVEPROP0("speed", lubEffects[i]->speed) << "," << std::endl;
 			SAVEPROP0("srcmode", lubEffects[i]->srcmode) << "," << std::endl;
 			SAVEPROP0("destmode", lubEffects[i]->destmode) << "," << std::endl;

--- a/browedit/windows/ObjectSelectWindow.cpp
+++ b/browedit/windows/ObjectSelectWindow.cpp
@@ -610,11 +610,12 @@ void BrowEdit::showObjectWindow()
 		{
 			static std::string currentFilterText = "";
 			static std::vector<std::string> filteredFiles;
-			util::tolowerInPlace(filter);
-			if (currentFilterText != filter)
+			std::string filter8859 = util::utf8_to_iso_8859_1(filter);
+			util::tolowerInPlace(filter8859);
+			if (currentFilterText != filter8859)
 			{
-				currentFilterText = filter;
-				std::vector<std::string> filterTags = util::split(filter, " ");
+				currentFilterText = filter8859;
+				std::vector<std::string> filterTags = util::split(filter8859, " ");
 				filteredFiles.clear();
 
 				for (auto t : tagListReverse)


### PR DESCRIPTION
Added array boundary checks for fetching alpha channel in images.
The sun distance with models will no longer impact shadows.
Fixed the lightmapper not fetching the correct model texture.
Recalculate the cullface value when recalculating the cached matrix.
Fixed object picker filter to support "gibberish" searches.
Added support for ensuring texture paths for lub textures are always valid.