### PR TITLE
Fixed auto-straight and rotated wall textures (and a few others)

### DIFF
--- a/browedit/Lightmapper.cpp
+++ b/browedit/Lightmapper.cpp
@@ -440,8 +440,12 @@ std::pair<glm::vec3, int> Lightmapper::calculateLight(const glm::vec3& groundPos
 		}
 		if (shadowStrength > 1)
 			shadowStrength = 1;
-		if (rswLight->diffuseLighting)
-			attenuation *= dotproduct;
+		if (rswLight->diffuseLighting) {
+			if (rswLight->lightType != RswLight::Type::Sun || settings.additiveShadow)
+				attenuation = attenuation * dotproduct;
+			else
+				attenuation = attenuation * (1 - dotproduct);
+		}
 		if (rswLight->affectShadowMap) {
 			if (settings.additiveShadow)
 				intensity += (int)((1 - shadowStrength) * attenuation * rswLight->intensity);
@@ -537,6 +541,7 @@ void Lightmapper::calcPos(int direction, int tileId, int x, int y)
 							std::cout << "uhoh";
 						}
 						normal.y *= -1;
+						normal.z *= -1;
 						normal = glm::normalize(normal);
 						groundPos = glm::vec3(p.x, h, p.y);
 					}

--- a/browedit/Map.cpp
+++ b/browedit/Map.cpp
@@ -840,16 +840,13 @@ void WallCalculation::calcUV(const glm::ivec3& position, Gnd* gnd)
 	if (position.z == 1 && position.x < gnd->width-1) //tileside
 	{
 		auto cube2 = gnd->cubes[position.x + 1][position.y];
-		if (cube->h2 > cube2->h1 && cube->h4 > cube2->h3)
-			index = (gnd->height - position.y - offset) % wallWidth;
+		index = (gnd->height - position.y - offset) % wallWidth;
 		minHeight = glm::min(glm::min(glm::min(-cube->h2, -cube->h4), -cube2->h1), -cube2->h3);
 		maxHeight = glm::max(glm::max(glm::max(-cube->h2, -cube->h4), -cube2->h1), -cube2->h3);
 	}
 	if (position.z == 2 && position.y < gnd->height-1) //tilefront
 	{
 		auto cube2 = gnd->cubes[position.x][position.y + 1];
-		if (cube2->h2 > cube->h4 && cube2->h1 > cube->h3)
-			index = (gnd->width - position.x - offset) % wallWidth;
 		minHeight = glm::min(glm::min(glm::min(-cube->h4, -cube->h3), -cube2->h2), -cube2->h1);
 		maxHeight = glm::max(glm::max(glm::max(-cube->h4, -cube->h3), -cube2->h2), -cube2->h1);
 	}
@@ -870,27 +867,6 @@ void WallCalculation::calcUV(const glm::ivec3& position, Gnd* gnd)
 	g_uv3.y = 1 - g_uv3.y;
 	g_uv4.y = 1 - g_uv4.y;
 
-	if (position.z == 2 && position.y < gnd->height-1) //tilefront
-	{
-		auto cube2 = gnd->cubes[position.x][position.y + 1];
-		if (cube2->h2 > cube->h4 && cube2->h1 > cube->h3)
-		{
-			std::swap(g_uv1.x, g_uv2.x);
-			std::swap(g_uv3.x, g_uv4.x);
-			std::swap(g_uv1.y, g_uv3.y);
-			std::swap(g_uv2.y, g_uv4.y);
-		}
-	}
-	if (position.z == 1 && position.x < gnd->width-1) //tileside
-	{
-		auto cube2 = gnd->cubes[position.x + 1][position.y];
-		if (cube->h2 < cube2->h1 && cube->h4 < cube2->h3)
-		{
-			std::swap(g_uv1.y, g_uv3.y);
-			std::swap(g_uv2.y, g_uv4.y);
-		}
-	}
-
 	if (autoStraight)
 	{
 		float h1 = -cube->h4;
@@ -910,26 +886,29 @@ void WallCalculation::calcUV(const glm::ivec3& position, Gnd* gnd)
 		}
 		else
 			return;
-		glm::vec2 guv1(g_uv1.x, glm::mix(g_uv1.y, g_uv3.y, (h1 - minHeight) / (maxHeight - minHeight)));
-		glm::vec2 guv2(g_uv2.x, glm::mix(g_uv2.y, g_uv4.y, (h2 - minHeight) / (maxHeight - minHeight)));
-		glm::vec2 guv3(g_uv3.x, glm::mix(g_uv1.y, g_uv3.y, (h3 - minHeight) / (maxHeight - minHeight)));
-		glm::vec2 guv4(g_uv4.x, glm::mix(g_uv2.y, g_uv4.y, (h4 - minHeight) / (maxHeight - minHeight)));
 
-		g_uv1 = guv1;
-		g_uv2 = guv2;
-		g_uv3 = guv3;
-		g_uv4 = guv4;
-		//if (position.z == 2 && gnd->cubes[position.x][position.y + 1]->h2 > cube->h4 && gnd->cubes[position.x][position.y + 1]->h1 > cube->h3)
-		//{
-		//	std::swap(g_uv1.y, g_uv2.y);
-		//	std::swap(g_uv3.y, g_uv4.y);
-		//}
-		//if (position.z == 1 && cube->h2 < gnd->cubes[position.x + 1][position.y]->h1 && cube->h4 < gnd->cubes[position.x + 1][position.y]->h3)
-		//{
-		//	std::swap(g_uv1.y, g_uv2.y);
-		//	std::swap(g_uv3.y, g_uv4.y);
-		//}
+		if (xInc.y == 0) {
+			glm::vec2 guv1(g_uv1.x, glm::mix(g_uv1.y, g_uv3.y, (h1 - minHeight) / (maxHeight - minHeight)));
+			glm::vec2 guv2(g_uv2.x, glm::mix(g_uv2.y, g_uv4.y, (h2 - minHeight) / (maxHeight - minHeight)));
+			glm::vec2 guv3(g_uv3.x, glm::mix(g_uv1.y, g_uv3.y, (h3 - minHeight) / (maxHeight - minHeight)));
+			glm::vec2 guv4(g_uv4.x, glm::mix(g_uv2.y, g_uv4.y, (h4 - minHeight) / (maxHeight - minHeight)));
 
+			g_uv1 = guv1;
+			g_uv2 = guv2;
+			g_uv3 = guv3;
+			g_uv4 = guv4;
+		}
+		else {
+			glm::vec2 guv1(glm::mix(g_uv1.x, g_uv3.x, (h1 - minHeight) / (maxHeight - minHeight)), g_uv1.y);
+			glm::vec2 guv2(glm::mix(g_uv2.x, g_uv4.x, (h2 - minHeight) / (maxHeight - minHeight)), g_uv2.y);
+			glm::vec2 guv3(glm::mix(g_uv1.x, g_uv3.x, (h3 - minHeight) / (maxHeight - minHeight)), g_uv3.y);
+			glm::vec2 guv4(glm::mix(g_uv2.x, g_uv4.x, (h4 - minHeight) / (maxHeight - minHeight)), g_uv4.y);
+
+			g_uv1 = guv1;
+			g_uv2 = guv2;
+			g_uv3 = guv3;
+			g_uv4 = guv4;
+		}
 	}
 
 }

--- a/browedit/MapView.Wallmode.cpp
+++ b/browedit/MapView.Wallmode.cpp
@@ -372,7 +372,7 @@ void MapView::postRenderWallMode(BrowEdit* browEdit)
 			}
 		}
 	}
-	if (selectedWalls.size() > 0)
+	if (selectedWalls.size() > 0 && browEdit->activeMapView)
 	{
 		std::vector<VertexP3T2N3> verts;
 		std::vector<VertexP3T2N3> topverts;

--- a/browedit/components/Gnd.h
+++ b/browedit/components/Gnd.h
@@ -214,6 +214,8 @@ public:
 
 		glm::vec3 normal;
 		glm::vec3 normals[4];
+		glm::vec3 normalsDefault[4];
+		glm::vec3 normalsForCalc[4];
 
 		void calcNormal();
 		void calcNormals(Gnd* gnd, int x, int y);

--- a/browedit/components/Rsm.cpp
+++ b/browedit/components/Rsm.cpp
@@ -317,6 +317,7 @@ Rsm::Mesh::Mesh(Rsm* model, std::istream* rsmFile)
 	offset[1][2] = rsmFile->readFloat();
 	offset[2][2] = rsmFile->readFloat();
 #endif
+	util::decompose(offset, offsetRotation, offsetScale, offsetPosition);
 
 	rsmFile->read(reinterpret_cast<char*>(glm::value_ptr(pos_)), sizeof(float) * 3);
 
@@ -411,24 +412,13 @@ Rsm::Mesh::Mesh(Rsm* model, std::istream* rsmFile)
 		for (auto& f : faces)
 			for (int i = 0; i < 3; i++)
 				for (int ii = 0; ii < 3; ii++)
-					if (f.smoothGroups[ii] != -1)
-						vertexNormals[f.smoothGroups[ii]][f.vertexIds[i]] += f.normal;
+					vertexNormals[f.smoothGroups[ii]][f.vertexIds[i]] += f.normal;
 		for (auto& f : faces)
 		{
-			for (int ii = 0; ii < 3; ii++)
-			{
-				if (f.smoothGroups[ii] != -1)
-				{
-					for (int i = 0; i < 3; i++)
-					{
-						if (ii == 0)
-							f.vertexNormals[i] = glm::vec3(0);
-						f.vertexNormals[i] += glm::normalize(vertexNormals[f.smoothGroups[0]][f.vertexIds[i]]);
-					}
-				}
-			}
 			for (int i = 0; i < 3; i++)
-				f.vertexNormals[i] = glm::normalize(f.vertexNormals[i]);
+			{
+				f.vertexNormals[i] = glm::normalize(vertexNormals[f.smoothGroups[0]][f.vertexIds[i]]);
+			}
 		}
 	}
 
@@ -542,6 +532,7 @@ void Rsm::Mesh::fetchChildren(std::map<std::string, Mesh* > meshes)
 void Rsm::Mesh::calcMatrix1(int time)
 {
 	matrix1 = glm::mat4(1.0f);
+	float cull = 1;
 
 	if (model->version < 0x0202) {
 		if (parent == NULL)
@@ -594,8 +585,7 @@ void Rsm::Mesh::calcMatrix1(int time)
 				quat = glm::normalize(quat);
 
 				matrix1 = matrix1 * glm::toMat4(quat);
-
-					}
+			}
 			else
 			{
 				matrix1 *= glm::toMat4(glm::normalize(rotFrames[0].quaternion));
@@ -603,6 +593,15 @@ void Rsm::Mesh::calcMatrix1(int time)
 		}
 
 		matrix1 = glm::scale(matrix1, scale);
+
+		// Cull face check
+		if (parent != nullptr)
+			cull = parent->reverseCullFaceSub ? -1.0f : 1.0f;
+
+		cull = cull * scale.x * scale.y * scale.z;
+		reverseCullFaceSub = cull < 0;
+		cull = cull * offsetScale.x * offsetScale.y * offsetScale.z;
+		reverseCullFace = cull < 0;
 	}
 	else {
 		matrix2 = glm::mat4(1.0f);
@@ -704,6 +703,11 @@ void Rsm::Mesh::calcMatrix1(int time)
 			matrix2[3].y += parent->matrix2[3].y;
 			matrix2[3].z += parent->matrix2[3].z;
 		}
+
+		// Cull face check
+		reverseCullFaceSub = cull < 0;
+		cull = cull * offsetScale.x * offsetScale.y * offsetScale.z;
+		reverseCullFace = cull < 0;
 	}
 
 	for (unsigned int i = 0; i < children.size(); i++)

--- a/browedit/components/Rsm.h
+++ b/browedit/components/Rsm.h
@@ -126,6 +126,13 @@ public:
 
 		Mesh* parent;
 
+		bool reverseCullFace;
+		bool reverseCullFaceSub;
+		// Decomposition values for the offset matrix
+		glm::vec3 offsetPosition;
+		glm::vec3 offsetScale;
+		glm::vec3 offsetRotation;
+
 		void fetchChildren(std::map<std::string, Mesh* > meshes);
 
 		void foreach(const std::function<void(Mesh*)>& callback)

--- a/browedit/components/RsmRenderer.cpp
+++ b/browedit/components/RsmRenderer.cpp
@@ -250,6 +250,7 @@ void RsmRenderer::renderMeshSub(Rsm::Mesh* mesh, bool selectionPhase)
 	{
 		vbo->bind();
 		shader->setUniform(RsmShader::Uniforms::modelMatrix, renderInfo[mesh->index].matrix);
+		shader->setUniform(RsmShader::Uniforms::reverseCullFace, mesh->reverseCullFace);
 		if (ri.selected || selectionPhase)
 			shader->setUniform(RsmShader::Uniforms::selection, 1.0f);
 		else if (!selectionPhase && selected)

--- a/browedit/shaders/RsmShader.h
+++ b/browedit/shaders/RsmShader.h
@@ -33,6 +33,7 @@ public:
 			//fogExp,
 			textureAnimToggle,
 			texMat,
+			reverseCullFace,
 			End
 		};
 	};
@@ -60,5 +61,6 @@ public:
 		//bindUniform(Uniforms::fogExp, "fogExp");
 		bindUniform(Uniforms::textureAnimToggle, "textureAnimToggle");
 		bindUniform(Uniforms::texMat, "texMat");
+		bindUniform(Uniforms::reverseCullFace, "reverseCullFace");
 	}
 };

--- a/browedit/util/Util.cpp
+++ b/browedit/util/Util.cpp
@@ -1945,6 +1945,50 @@ namespace util
 		return "";
 	}
 
+	void decompose(glm::mat4 m, glm::vec3& euler, glm::vec3& scale, glm::vec3& translation) {
+		scale.x = glm::length(m[0]);
+		scale.y = glm::length(m[1]);
+		scale.z = glm::length(m[2]);
+
+		auto Pdum3 = glm::cross(glm::vec3(m[1]), glm::vec3(m[2]));
+		if (glm::dot(glm::vec3(m[0]), Pdum3) < 0) {
+			scale *= -1;
+		}
+
+		translation = glm::vec3(m[3]);
+
+		for (int i = 0; i < 3; i++) {
+			if (scale[i] == 0) continue;
+			for (int j = 0; j < 4; j++)
+				m[i][j] = m[i][j] / scale[i];
+		}
+
+		float m11 = m[0][0];
+		float m12 = m[0][1];
+		float m13 = m[0][2];
+
+		float m21 = m[1][0];
+		float m22 = m[1][1];
+		float m23 = m[1][2];
+
+		float m31 = m[2][0];
+		float m32 = m[2][1];
+		float m33 = m[2][2];
+
+		euler.x = asin(glm::clamp(m23, -1.0f, 1.0f));
+
+		if (glm::abs(m23) < 0.9999999f) {
+			euler.y = atan2(m13, m33);
+			euler.z = atan2(m21, m22);
+		}
+		else {
+			euler.y = atan2(-m31, m11);
+			euler.z = 0.0f;
+		}
+
+		euler = glm::degrees(euler);
+	}
+
 }
 
 

--- a/browedit/util/Util.h
+++ b/browedit/util/Util.h
@@ -135,6 +135,7 @@ namespace util
 
 
 	std::string callstack();
+	void decompose(glm::mat4 m, glm::vec3& euler, glm::vec3& scale, glm::vec3& translation);
 }
 
 namespace glm

--- a/data/shaders/gnd.fs
+++ b/data/shaders/gnd.fs
@@ -3,9 +3,6 @@
 uniform sampler2D s_texture;
 uniform sampler2D s_lighting;
 
-uniform vec3 lightDiffuse;
-uniform vec3 lightAmbient;
-uniform vec3 lightDirection;
 //uniform float lightIntensity;
 uniform float lightToggle = 1.0f;
 uniform float colorToggle = 1.0f;
@@ -25,6 +22,7 @@ in vec2 texCoord;
 in vec2 texCoord2;
 in vec3 normal;
 in vec4 color;
+in vec3 mult;
 
 out vec4 fragColor;
 in vec3 fragPos;
@@ -65,15 +63,7 @@ void main()
 	for (int i = 0; i < lightCount; i++)
         light.rgb += CalcPointLight(lights[i], normalize(normal), fragPos);
 	
-	float NL = clamp(dot(normalize(normal), vec3(1,-1,1)*lightDirection),0.0,1.0);
-	vec3 ambientFactor = (1.0 - lightAmbient) * lightAmbient;
-	vec3 ambient = lightAmbient - ambientFactor + ambientFactor * lightDiffuse;
-	vec3 diffuseFactor = (1.0 - lightDiffuse) * lightDiffuse;
-	vec3 diffuse = lightDiffuse - diffuseFactor + diffuseFactor * lightAmbient;
-	vec3 mult1 = min(NL * diffuse + ambient, 1.0);
-	// The formula quite literally changes when the combined value of lightAmbient + lightDiffuse is greater than 1.0
-	vec3 mult2 = min(max(lightDiffuse, lightAmbient) + (1.0 - max(lightDiffuse, lightAmbient)) * min(lightDiffuse, lightAmbient), 1.0);
-	texture.rgb *= min(mult1, mult2);
+	texture.rgb *= mult;
 	texture.rgb *= max(color, colorToggle).rgb;
 	texture.rgb *= max(texture2D(s_lighting, texCoord2).a, shadowMapToggle);
 	
@@ -101,7 +91,6 @@ void main()
 // calculates the color when using a point light.
 vec3 CalcPointLight(Light light, vec3 normal, vec3 inFragPos)
 {
-	normal = vec3(normal.x, -normal.y, normal.z);
 	vec3 lightDir = normalize(light.position - inFragPos);
     float distance = length(light.position - inFragPos);
 	

--- a/data/shaders/gnd.vs
+++ b/data/shaders/gnd.vs
@@ -8,11 +8,15 @@ layout (location = 4) in vec3 a_normal;
 
 uniform mat4 projectionMatrix;
 uniform mat4 modelViewMatrix;
+uniform vec3 lightDiffuse;
+uniform vec3 lightAmbient;
+uniform vec3 lightDirection;
 
 out vec2 texCoord;
 out vec2 texCoord2;
 out vec3 normal;
 out vec4 color;
+out vec3 mult;
 out vec3 fragPos;
 
 void main()
@@ -22,5 +26,18 @@ void main()
 	normal = a_normal;
 	color = a_color;
 	fragPos = a_position;
+	
+	// The light calculation is done on the vertex shader for linear color interpolation,
+	// which is what the official client does.
+	float NL = clamp(dot(normalize(normal), -1.0f * lightDirection),0.0,1.0);
+	vec3 ambientFactor = (1.0 - lightAmbient) * lightAmbient;
+	vec3 ambient = lightAmbient - ambientFactor + ambientFactor * lightDiffuse;
+	vec3 diffuseFactor = (1.0 - lightDiffuse) * lightDiffuse;
+	vec3 diffuse = lightDiffuse - diffuseFactor + diffuseFactor * lightAmbient;
+	vec3 mult1 = min(NL * diffuse + ambient, 1.0);
+	// The formula quite literally changes when the combined value of lightAmbient + lightDiffuse is greater than 1.0
+	vec3 mult2 = min(max(lightDiffuse, lightAmbient) + (1.0 - max(lightDiffuse, lightAmbient)) * min(lightDiffuse, lightAmbient), 1.0);
+	mult = clamp(min(mult1, mult2), 0.0, 1.0);
+
 	gl_Position = projectionMatrix * modelViewMatrix * vec4(a_position,1);
 }

--- a/data/shaders/rsm.fs
+++ b/data/shaders/rsm.fs
@@ -11,6 +11,7 @@ uniform float selection;
 uniform bool lightToggle;
 uniform bool viewTextures;
 uniform bool enableCullFace;
+uniform bool reverseCullFace;
 in float cull;
 
 uniform bool fogEnabled;
@@ -21,6 +22,7 @@ uniform vec4 fogColor;
 
 varying vec2 texCoord;
 varying vec3 normal;
+varying vec3 mult;
 
 //texture animation
 uniform bool textureAnimToggle;
@@ -54,14 +56,7 @@ void main()
 			color.rgb *= min(max(lightDiffuse, lightAmbient) + (1.0 - max(lightDiffuse, lightAmbient)) * min(lightDiffuse, lightAmbient), 1.0);
 		}
 		else {
-			float NL = clamp(dot(normalize(normal), lightDirection),0.0,1.0);
-			vec3 ambientFactor = (1.0 - lightAmbient) * lightAmbient;
-			vec3 ambient = lightAmbient - ambientFactor + ambientFactor * lightDiffuse;
-			vec3 diffuseFactor = (1.0 - lightDiffuse) * lightDiffuse;
-			vec3 diffuse = lightDiffuse - diffuseFactor + diffuseFactor * lightAmbient;
-			vec3 mult1 = min(NL * diffuse + ambient, 1.0);
-			vec3 mult2 = min(max(lightDiffuse, lightAmbient) + (1.0 - max(lightDiffuse, lightAmbient)) * min(lightDiffuse, lightAmbient), 1.0);
-			color.rgb *= min(mult1, mult2);
+			color.rgb *= mult;
 		}
 	}
 	

--- a/data/shaders/rsm.vs
+++ b/data/shaders/rsm.vs
@@ -12,20 +12,41 @@ uniform mat4 modelMatrix2;
 uniform float billboard = 0.0f;
 uniform float selection;
 
+uniform vec3 lightDiffuse;
+uniform vec3 lightAmbient;
+uniform vec3 lightDirection;
+uniform bool reverseCullFace;
+
 out vec2 texCoord;
 out vec3 normal;
+out vec3 mult;
 out float cull;
 
 void main()
 {
 	mat3 normalMatrix = mat3(modelMatrix2 * modelMatrix); //TODO: move this to C++ code
-	normalMatrix = transpose(inverse(normalMatrix));
 	normal = normalMatrix * a_normal;
+	normal = normalize(normal);
 	cull = a_cull;
 
 	texCoord = a_texture;
 	vec4 billboarded = projectionMatrix * (cameraMatrix * modelMatrix) * vec4(0.0,0.0,0.0,1.0) +  modelMatrix2 * vec4(a_position.x, a_position.y,0.0,1.0);
 	vec4 position = projectionMatrix * cameraMatrix * modelMatrix2 * modelMatrix * vec4(a_position,1.0);
 
+	// Calculate shading on the vertex instead of fragment shader for better smoothing
+	vec3 normal2 = normal;
+	
+	if (reverseCullFace)
+		normal2 *= -1;
+	
+	float NL = clamp(dot(normal2, lightDirection), 0.0, 1.0);
+	vec3 ambientFactor = (1.0 - lightAmbient) * lightAmbient;
+	vec3 ambient = lightAmbient - ambientFactor + ambientFactor * lightDiffuse;
+	vec3 diffuseFactor = (1.0 - lightDiffuse) * lightDiffuse;
+	vec3 diffuse = lightDiffuse - diffuseFactor + diffuseFactor * lightAmbient;
+	vec3 mult1 = min(NL * diffuse + ambient, 1.0);
+	vec3 mult2 = min(max(lightDiffuse, lightAmbient) + (1.0 - max(lightDiffuse, lightAmbient)) * min(lightDiffuse, lightAmbient), 1.0);
+	mult = min(mult1, mult2);
+	
 	gl_Position = mix(position, billboarded, billboard);
 }


### PR DESCRIPTION
Fixed auto-straight and rotated wall textures not being applied correctly.
Fixed a crash when opening a new map with a previously selected wall (on a closed map). Inverted the Y-axis for the cube normals.
Replicated the cube normals' behavior to match with the client. Inverted normal for cube tileSide and tileFront depending on its facing direction. Flipped cube tileSide's triangles (p0-p1-p2 to p0-p2-p3). No longer ignores smoothGroup -1 when calculating mesh normals. Ground and model shading are now applied on the vertex shader rather than the fragment shader for smoother gradients (reflects the client behavior).