### PR TITLE
Variety of lub fixes

### DIFF
--- a/browedit/Lightmapper.cpp
+++ b/browedit/Lightmapper.cpp
@@ -432,7 +432,7 @@ std::pair<glm::vec3, int> Lightmapper::calculateLight(const glm::vec3& groundPos
 				}
 			}
 			// Check if the ray collides with the ground
-			if (!collides && shadowStrength < 1 && rswLight->shadowTerrain && rswLight->givesShadow && collidesMap(math::Ray(groundPos, lightDirection2), cx, cy, distance))
+			if (!collides && shadowStrength < 1 && rswLight->shadowTerrain && collidesMap(math::Ray(groundPos, lightDirection2), cx, cy, distance))
 			{
 				collides = true;
 				shadowStrength = 1;

--- a/browedit/MapView.cpp
+++ b/browedit/MapView.cpp
@@ -901,9 +901,8 @@ void MapView::drawLight(Node* n)
 	auto rswLight = n->getComponent<RswLight>();
 	auto gnd = n->root->getComponent<Gnd>();
 
-	if (rswLight->lightType == RswLight::Type::Sun)
+	if (rswLight->lightType == RswLight::Type::Sun || gnd == nullptr)
 		return;
-
 
 	glm::mat4 modelMatrix(1.0f);
 	modelMatrix = glm::scale(modelMatrix, glm::vec3(1, 1, -1));

--- a/browedit/components/LubRenderer.cpp
+++ b/browedit/components/LubRenderer.cpp
@@ -36,6 +36,9 @@ int d3dToOpenGlBlend(int d3d)
 	case 8:		return GL_ONE_MINUS_DST_ALPHA;
 	case 9:		return GL_DST_COLOR;
 	case 10:	return GL_ONE_MINUS_DST_COLOR;
+	case 11:	return GL_SRC_ALPHA_SATURATE;
+	case 12:	return GL_SRC_ALPHA;
+	case 13:	return GL_ONE_MINUS_SRC_ALPHA;
 	}
 	return GL_ONE;
 }
@@ -75,7 +78,7 @@ void LubRenderer::render()
 
 	glm::mat4 modelMatrix(1.0f);
 	modelMatrix = glm::scale(modelMatrix, glm::vec3(1, 1, -1));
-	modelMatrix = glm::translate(modelMatrix, glm::vec3(5 * gnd->width + rswObject->position.x, -rswObject->position.y + 11, -9 - 5 * gnd->height + rswObject->position.z));
+	modelMatrix = glm::translate(modelMatrix, glm::vec3(5 * gnd->width + rswObject->position.x, -rswObject->position.y + 10, -10 - 5 * gnd->height + rswObject->position.z));
 
 	if (lubEffect->billboard_off) {
 		modelMatrix = glm::rotate(modelMatrix, -glm::radians(lubEffect->rotate_angle.z), glm::vec3(0, 0, 1));
@@ -83,8 +86,12 @@ void LubRenderer::render()
 		modelMatrix = glm::rotate(modelMatrix, -glm::radians(lubEffect->rotate_angle.x), glm::vec3(1, 0, 0));
 	}
 
+	// Gravity somehow decided to move it by 1 on the Z axis, making the center rotation off.
+	modelMatrix = glm::translate(modelMatrix, glm::vec3(0, 0, 1));
+
 	shader->setUniform(LubShader::Uniforms::billboard_off, (bool)lubEffect->billboard_off);
-	shader->setUniform(LubShader::Uniforms::color, glm::vec4(lubEffect->color.r, lubEffect->color.g, lubEffect->color.b, 1.0f));
+	shader->setUniform(LubShader::Uniforms::scale, lubEffect->scale);
+	shader->setUniform(LubShader::Uniforms::color, glm::vec4(lubEffect->color.r, lubEffect->color.g, lubEffect->color.b, lubEffect->color.a));
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	if (texture)
@@ -95,28 +102,36 @@ void LubRenderer::render()
 	float time = (float)glfwGetTime();
 	float elapsedTime = time - lastTime;
 	lastTime = time;
-	for (auto& p : particles)
-	{
-		p.position += (p.dir * lubEffect->speed + p.speed) * elapsedTime;
-		p.life -= elapsedTime;
-		p.speed += lubEffect->speed * lubEffect->gravity * glm::vec3(1, -1, 1) * elapsedTime;
+	for (int i = 0; i < particles.size(); i++) {
+		auto p = &particles[i];
+		float t = time - p->tickStart;
+		p->position = p->startPosition + p->dir * lubEffect->speed * t + lubEffect->gravity * glm::vec3(1, -1, 1) * lubEffect->speed * t * t * 0.5f;
 
-		if (p.start_life > 1) {
-			if (p.life < glm::min(1.0f, p.start_life / 2.0f))
-				p.alpha -= elapsedTime;
+		if (lubEffect->eternity)
+			p->alpha = 1;
+		else if (p->duration > 1) {
+			float tRemaining = p->tickStart + p->duration - time;
+			if (t < 1)
+				p->alpha = t;
+			else if (tRemaining < 1)
+				p->alpha = tRemaining;
 			else
-				p.alpha += elapsedTime;
-
-			p.alpha = glm::clamp(p.alpha, 0.0f, 1.0f);
+				p->alpha = 1;
 		}
+
+		if (!lubEffect->eternity && time >= p->tickStart + p->duration)
+			p->toDelete = true;
+		if (i >= lubEffect->maxcount)
+			p->toDelete = true;
 	}
+
 	if (particles.size() > 0)
-		particles.erase(std::remove_if(particles.begin(), particles.end(), [](const Particle& p) { return p.life < 0; }), particles.end());
-	emitTime -= elapsedTime;
-	if (emitTime < 0 && particles.size() < lubEffect->maxcount)
+		particles.erase(std::remove_if(particles.begin(), particles.end(), [](const Particle& p) { return p.toDelete; }), particles.end());
+	
+	if (time >= nextEmitTime && particles.size() < lubEffect->maxcount)
 	{
 		Particle p;
-		p.position = glm::vec3(
+		p.position = p.startPosition = glm::vec3(
 			-lubEffect->radius.x + (rand() / (float)RAND_MAX) * (-lubEffect->radius.x + 2 * abs(lubEffect->radius.x) + lubEffect->radius.x),
 			-lubEffect->radius.y + (rand() / (float)RAND_MAX) * (-lubEffect->radius.y + 2 * abs(lubEffect->radius.y) + lubEffect->radius.y),
 			-lubEffect->radius.z + (rand() / (float)RAND_MAX) * (-lubEffect->radius.z + 2 * abs(lubEffect->radius.z) + lubEffect->radius.z)
@@ -127,13 +142,14 @@ void LubRenderer::render()
 			-lubEffect->dir1.y + (rand() / (float)RAND_MAX) * (-lubEffect->dir2.y + lubEffect->dir1.y),
 			lubEffect->dir1.z + (rand() / (float)RAND_MAX) * (lubEffect->dir2.z - lubEffect->dir1.z)
 		);
-		p.life = lubEffect->life.x + (rand() / (float)RAND_MAX) * (lubEffect->life.y - lubEffect->life.x);
-		p.start_life = p.life;
+		p.duration = lubEffect->life.x + (rand() / (float)RAND_MAX) * (lubEffect->life.y - lubEffect->life.x);
+		p.tickStart = time;
 		p.size = lubEffect->size.x + (rand() / (float)RAND_MAX) * (lubEffect->size.y - lubEffect->size.x);
 		p.alpha = 0;
+		p.toDelete = false;
 
 		particles.push_back(p);
-		emitTime = 1.0f / (lubEffect->rate.x + (rand() / (float)RAND_MAX) * (lubEffect->rate.y - lubEffect->rate.x));
+		nextEmitTime = time + 1.0f / (lubEffect->rate.x + (rand() / (float)RAND_MAX) * (lubEffect->rate.y - lubEffect->rate.x));
 	}
 
 	if (lubEffect->zenable)
@@ -146,21 +162,21 @@ void LubRenderer::render()
 	glBlendFuncSeparate(src, dst, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 	glDepthMask(0);
 
-	std::vector<VertexP3T2A1> verts;
+	std::vector<VertexP2T2A1> verts;
 	for (const auto& p : particles)
 	{
 		float alpha = p.alpha;
-		verts.push_back(VertexP3T2A1(glm::vec3(-p.size, -p.size, 0), glm::vec2(0, 0), alpha));
-		verts.push_back(VertexP3T2A1(glm::vec3(-p.size, p.size, 0), glm::vec2(0, 1), alpha));
-		verts.push_back(VertexP3T2A1(glm::vec3(p.size, p.size, 0), glm::vec2(1, 1), alpha));
-		verts.push_back(VertexP3T2A1(glm::vec3(p.size, -p.size, 0), glm::vec2(1, 0), alpha));
+		verts.push_back(VertexP2T2A1(glm::vec2(-p.size, -p.size), glm::vec2(0, 0), alpha));
+		verts.push_back(VertexP2T2A1(glm::vec2(-p.size, p.size), glm::vec2(0, 1), alpha));
+		verts.push_back(VertexP2T2A1(glm::vec2(p.size, p.size), glm::vec2(1, 1), alpha));
+		verts.push_back(VertexP2T2A1(glm::vec2(p.size, -p.size), glm::vec2(1, 0), alpha));
 	}
 
 	if (verts.size() > 0)
 	{
-		glVertexAttribPointer(0, 3, GL_FLOAT, false, sizeof(VertexP3T2A1), verts[0].data);
-		glVertexAttribPointer(1, 2, GL_FLOAT, false, sizeof(VertexP3T2A1), verts[0].data + 3);
-		glVertexAttribPointer(2, 1, GL_FLOAT, false, sizeof(VertexP3T2A1), verts[0].data + 5);
+		glVertexAttribPointer(0, 2, GL_FLOAT, false, sizeof(VertexP2T2A1), verts[0].data);
+		glVertexAttribPointer(1, 2, GL_FLOAT, false, sizeof(VertexP2T2A1), verts[0].data + 2);
+		glVertexAttribPointer(2, 1, GL_FLOAT, false, sizeof(VertexP2T2A1), verts[0].data + 4);
 	}
 
 	for (int i = 0; i < particles.size(); i++)

--- a/browedit/components/LubRenderer.h
+++ b/browedit/components/LubRenderer.h
@@ -27,6 +27,7 @@ public:
 				s_texture,
 				color,
 				billboard_off,
+				scale,
 				selection,
 				End
 			};
@@ -39,6 +40,7 @@ public:
 			bindUniform(Uniforms::modelMatrix, "modelMatrix");
 			bindUniform(Uniforms::color, "color");
 			bindUniform(Uniforms::billboard_off, "billboard_off");
+			bindUniform(Uniforms::scale, "scale");
 			bindUniform(Uniforms::selection, "selection");
 		}
 	};
@@ -51,17 +53,19 @@ private:
 	gl::Texture* texture = nullptr;
 
 	float lastTime;
-	float emitTime = 0;
+	float nextEmitTime = 0;
 	class Particle
 	{
 	public:
+		glm::vec3 startPosition;
 		glm::vec3 position;
 		glm::vec3 speed;
 		glm::vec3 dir;
 		float size;
-		float life;
-		float start_life;
 		float alpha;
+		float duration;
+		float tickStart;
+		bool toDelete;
 	};
 	std::vector<Particle> particles;
 

--- a/browedit/components/Rsm.cpp
+++ b/browedit/components/Rsm.cpp
@@ -383,7 +383,7 @@ Rsm::Mesh::Mesh(Rsm* model, std::istream* rsmFile)
 				rsmFile->read(reinterpret_cast<char*>(&f->smoothGroups[2]), sizeof(int));
 			for(int i = 32; i < len; i+=4)
 			{
-				std::cout << "Model " << model->fileName << " has too many smooth groups. Please contact borf" << std::endl;
+				// Tokei: those are group masks from 3DS models, actually. So the smoothGroups don't belong to a vertex, but rather is a single big ID flag.
 				int tmp;
 				rsmFile->read(reinterpret_cast<char*>(&tmp), sizeof(int));
 			}

--- a/browedit/components/Rsw.Effect.cpp
+++ b/browedit/components/Rsw.Effect.cpp
@@ -101,7 +101,7 @@ void LubEffect::load(const json& data)
 	from_json(data["gravity"], gravity);
 	from_json(data["pos"], pos);
 	from_json(data["radius"], radius);
-	if(data.size() == 4)
+	if(data["color"].size() == 4)
 		from_json(data["color"], color);
 	else
 	{
@@ -123,6 +123,10 @@ void LubEffect::load(const json& data)
 	
 	if (data.find("billboard_off") != data.end())
 		billboard_off = data["billboard_off"][0];
+	if (data.find("eternity") != data.end())
+		eternity = data["eternity"][0];
+	if (data.find("scale") != data.end())
+		from_json(data["scale"], scale);
 	if (data.find("rotate_angle") != data.end())
 		from_json(data["rotate_angle"], rotate_angle);
 }
@@ -180,6 +184,7 @@ void LubEffect::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& no
 		util::ColorEdit4Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "color", [](LubEffect* e) {return &e->color; });
 		util::DragFloat2Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "rate", [](LubEffect* e) {return &e->rate; }, 0.1f, 0, 0);
 		util::DragFloat2Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "size", [](LubEffect* e) {return &e->size; }, 0.1f, 0, 0);
+		util::DragFloat2Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "scale", [](LubEffect* e) {return &e->scale; }, 0.1f, 0, 0);
 		util::DragFloat2Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "life", [](LubEffect* e) {return &e->life; }, 0.1f, 0, 0);
 		util::InputTextMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "texture", [](LubEffect* e) {return &e->texture;}, [&](Node* node, std::string* ptr, std::string* startValue, const std::string& action) {
 			browEdit->activeMapView->map->doAction(new LubChangeTextureAction(node->getComponent<LubEffect>(), *startValue, *ptr), browEdit);
@@ -191,6 +196,7 @@ void LubEffect::buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>& no
 		util::DragIntMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "zenable", [](LubEffect* e) {return &e->zenable; }, 1, 0, 1);
 		util::DragIntMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "billboard_off ", [](LubEffect* e) {return &e->billboard_off; }, 1, 0, 1);
 		util::DragFloat3Multi<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "rotate_angle", [](LubEffect* e) {return &e->rotate_angle; }, 1.0f, 0, 360);
+		util::DragIntMulti<LubEffect>(browEdit, browEdit->activeMapView->map, lubEffects, "eternity", [](LubEffect* e) {return &e->eternity; }, 1, 0, 1);
 	}
 
 }

--- a/browedit/components/Rsw.Model.cpp
+++ b/browedit/components/Rsw.Model.cpp
@@ -16,7 +16,7 @@ RswModel::RswModel(RswModel* other) : aabb(other->aabb), animType(other->animTyp
 {
 }
 
-void RswModel::load(std::istream* is, int version, unsigned char buildNumber, bool loadModel)
+void RswModel::load(std::istream* is, int version, int buildNumber, bool loadModel)
 {
 	auto rswObject = node->getComponent<RswObject>();
 	if (version >= 0x103)

--- a/browedit/components/Rsw.Object.cpp
+++ b/browedit/components/Rsw.Object.cpp
@@ -21,10 +21,11 @@ RswObject::RswObject(RswObject* other) : position(other->position), rotation(oth
 {
 }
 
-void RswObject::load(std::istream* is, int version, unsigned char buildNumber, bool loadModel)
+void RswObject::load(std::istream* is, int version, int buildNumber, bool loadModel)
 {
 	int type;
 	is->read(reinterpret_cast<char*>(&type), sizeof(int));
+
 	if (type == 1)
 	{
 //		std::cout << "Loading model" << std::endl;

--- a/browedit/components/Rsw.cpp
+++ b/browedit/components/Rsw.cpp
@@ -643,6 +643,7 @@ void Rsw::save(const std::string& fileName, BrowEdit* browEdit)
 			SAVEPROP4("color", glm::round(lubEffects[i]->color * 255.0f)) << "," << std::endl;
 			SAVEPROP2("rate", lubEffects[i]->rate) << "," << std::endl;
 			SAVEPROP2("size", lubEffects[i]->size) << "," << std::endl;
+			SAVEPROP2("scale", lubEffects[i]->scale) << "," << std::endl;
 			SAVEPROP2("life", lubEffects[i]->life) << "," << std::endl;
 			SAVEPROPS("texture", util::replace(util::replace(lubEffects[i]->texture, "\\\\", "\\"), "\\", "\\\\")) << "," << std::endl;
 			SAVEPROP0("speed", lubEffects[i]->speed) << "," << std::endl;
@@ -651,7 +652,8 @@ void Rsw::save(const std::string& fileName, BrowEdit* browEdit)
 			SAVEPROP0("maxcount", lubEffects[i]->maxcount) << "," << std::endl;
 			SAVEPROP0("zenable", lubEffects[i]->zenable) << "," << std::endl;
 			SAVEPROP0("billboard_off", lubEffects[i]->billboard_off) << "," << std::endl;
-			SAVEPROP3("rotate_angle", lubEffects[i]->rotate_angle) << std::endl;
+			SAVEPROP3("rotate_angle", lubEffects[i]->rotate_angle) << "," << std::endl;
+			SAVEPROP0("eternity", lubEffects[i]->eternity) << std::endl;
 
 
 			lubFile << "\t}";

--- a/browedit/components/Rsw.h
+++ b/browedit/components/Rsw.h
@@ -180,7 +180,7 @@ public:
 
 	RswObject() {}
 	RswObject(RswObject* other);
-	void load(std::istream* is, int version, unsigned char buildNumber, bool loadModel);
+	void load(std::istream* is, int version, int buildNumber, bool loadModel);
 	void save(std::ofstream& file, Rsw *rsw);
 	static void buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>&);
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE(RswObject, position, rotation, scale);
@@ -205,7 +205,7 @@ public:
 	RswModel() : aabb(glm::vec3(), glm::vec3()) {}
 	RswModel(const std::string &fileName) : aabb(glm::vec3(), glm::vec3()), animType(0), animSpeed(1), blockType(0), fileName(fileName) {}
 	RswModel(RswModel* other);
-	void load(std::istream* is, int version, unsigned char buildNumber, bool loadModel);
+	void load(std::istream* is, int version, int buildNumber, bool loadModel);
 	void loadExtra(nlohmann::json data);
 	void save(std::ofstream &file, int version, int buildNumber);
 	nlohmann::json saveExtra();
@@ -277,6 +277,7 @@ public:
 	glm::vec2 rate;
 	glm::vec2 size;
 	glm::vec2 life;
+	glm::vec2 scale = glm::vec2(1, 1);
 	std::string texture;
 	float speed;
 	int srcmode;
@@ -284,12 +285,13 @@ public:
 	int maxcount;
 	int zenable;
 	int billboard_off;
+	int eternity;
 	glm::vec3 rotate_angle; // v3
 	bool dirty;
 
 	void load(const nlohmann::json& data);
 	static void buildImGuiMulti(BrowEdit* browEdit, const std::vector<Node*>&);
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE(LubEffect, dir1, dir2, gravity, pos, radius, color, rate, size, life, texture, speed, srcmode, destmode, maxcount, zenable, billboard_off, rotate_angle);
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(LubEffect, dir1, dir2, gravity, pos, radius, color, rate, size, life, scale, texture, speed, srcmode, destmode, maxcount, zenable, billboard_off, eternity, rotate_angle);
 };
 
 class RswEffect : public Component

--- a/browedit/gl/Vertex.h
+++ b/browedit/gl/Vertex.h
@@ -167,10 +167,10 @@
 		}
 	};
 
-	class VertexP3T2A1 : public Vert<3 + 2 + 1>
+	class VertexP2T2A1 : public Vert<3 + 2 + 1>
 	{
 	public:
-		VertexP3T2A1(const glm::vec3& pos, const glm::vec2& t, float alpha)
+		VertexP2T2A1(const glm::vec2& pos, const glm::vec2& t, float alpha)
 		{
 			int index = 0;
 			set(pos, index);

--- a/browedit/windows/ObjectSelectWindow.cpp
+++ b/browedit/windows/ObjectSelectWindow.cpp
@@ -375,11 +375,13 @@ void BrowEdit::showObjectWindow()
 								lubEffect->rate = glm::vec2(5, 15);
 								lubEffect->size = glm::vec2(3, 8);
 								lubEffect->life = glm::vec2(1, 5);
+								lubEffect->scale = glm::vec2(1, 1);
 								lubEffect->speed = 0.5f;
 								lubEffect->srcmode = 10;
 								lubEffect->destmode = 2;
 								lubEffect->maxcount = 30;
 								lubEffect->zenable = 1;
+								lubEffect->eternity = 0;
 
 								newNode->addComponent(new LubRenderer());
 							}

--- a/data/shaders/lub.fs
+++ b/data/shaders/lub.fs
@@ -16,7 +16,7 @@ void main()
 	else {
 		vec4 outColor = texture2D(s_texture, texCoord);
 		outColor *= color;
-		outColor.a *= alpha;
+		outColor.a = alpha;
 		fragColor = outColor;
 	}
 }

--- a/data/shaders/lub.vs
+++ b/data/shaders/lub.vs
@@ -1,6 +1,6 @@
 #version 420
 
-layout (location = 0) in vec3 a_position;
+layout (location = 0) in vec2 a_position;
 layout (location = 1) in vec2 a_texture;
 layout (location = 2) in float a_alpha;
 
@@ -8,6 +8,7 @@ uniform mat4 projectionMatrix;
 uniform mat4 cameraMatrix;
 uniform mat4 modelMatrix;
 uniform bool billboard_off;
+uniform vec2 scale;
 
 out vec2 texCoord;
 out float alpha;
@@ -17,13 +18,15 @@ void main()
 	texCoord = a_texture;
 	alpha = a_alpha;
 	
+	vec2 position = a_position * scale;
+	
 	if (billboard_off) {
-		vec4 billboarded = projectionMatrix * (cameraMatrix * modelMatrix) * vec4(a_position,1.0);
+		vec4 billboarded = projectionMatrix * (cameraMatrix * modelMatrix) * vec4(position,0.0,1.0);
 		gl_Position = billboarded;
 	}
 	else {
 		vec4 billboarded = projectionMatrix * (cameraMatrix * modelMatrix) * vec4(0.0,0.0,0.0,1.0);
-		billboarded.xy += (projectionMatrix * vec4(a_position.x, a_position.y,0.0,1.0)).xy;
+		billboarded.xy += (projectionMatrix * vec4(position.x, position.y,0.0,1.0)).xy;
 		gl_Position = billboarded;
 	}
 }


### PR DESCRIPTION
Lights with "Gives Shadows" unchecked will now also collide with walls.
Fixed a couple of lub effect issues. Missing DirectX types, wrong position, alpha channel not handled correctly, missing new scale and eternity properties.
Fixed the RSW buildNumber argument being the wrong type, newer maps' objects will now load correctly.