### PR TITLE
Start BrowEdit in maximized window

### DIFF
--- a/browedit/BrowEdit.glfw.cpp
+++ b/browedit/BrowEdit.glfw.cpp
@@ -72,6 +72,7 @@ bool BrowEdit::glfwBegin()
     //#ifdef _DEBUG
         glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
     //#endif
+    glfwWindowHint(GLFW_MAXIMIZED, GLFW_TRUE);
     window = glfwCreateWindow(1920, 1080, "BrowEdit V3." QUOTE(VERSION), NULL, NULL);
 
     if (window == nullptr)


### PR DESCRIPTION
Added one line so GLFW window starts in maximized window instead of windowed mode.