### PR TITLE
Use resource icon as GLFW window icon

### DIFF
--- a/browedit/BrowEdit.glfw.cpp
+++ b/browedit/BrowEdit.glfw.cpp
@@ -84,6 +84,15 @@ bool BrowEdit::glfwBegin()
     glfwMakeContextCurrent(window);
     glfwSwapInterval(1); // Enable vsync
 
+    #ifdef _WIN32
+        HWND hwnd = glfwGetWin32Window(window);
+        HICON hIcon = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(101)); 
+        if (hIcon)
+        {
+            SendMessage(hwnd, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
+            SendMessage(hwnd, WM_SETICON, ICON_SMALL, (LPARAM)hIcon);
+        }
+    #endif
 
     if (
         !gladLoadGL((GLADloadfunc)glfwGetProcAddress)


### PR DESCRIPTION
The GLFW window will load IDI_ICON1 from resource and use it as its icon so no more default Windows application icon.

<img width="219" height="225" alt="image" src="https://github.com/user-attachments/assets/b06ae34f-6ff4-40e0-9d27-414a4ca8f3a7" />
