### PR TITLE
Fixed water edit mode broken snap grid look

### DIFF
--- a/browedit/MapView.Watermode.cpp
+++ b/browedit/MapView.Watermode.cpp
@@ -326,11 +326,12 @@ void MapView::postRenderWaterMode(BrowEdit* browEdit)
 					glLineWidth(2);
 					gridVbo->bind();
 					glEnableVertexAttribArray(0);
-					glDisableVertexAttribArray(1);
+					glEnableVertexAttribArray(1);
 					glDisableVertexAttribArray(2);
 					glDisableVertexAttribArray(3);
-					glDisableVertexAttribArray(4);
-					glVertexAttribPointer(0, 3, GL_FLOAT, false, sizeof(VertexP3), (void*)(0 * sizeof(float)));
+					glDisableVertexAttribArray(4); //TODO: vao
+					glVertexAttribPointer(0, 3, GL_FLOAT, false, sizeof(VertexP3T2), (void*)(0 * sizeof(float)));
+					glVertexAttribPointer(1, 2, GL_FLOAT, false, sizeof(VertexP3T2), (void*)(3 * sizeof(float)));
 					glDrawArrays(GL_LINES, 0, (int)gridVbo->size());
 					gridVbo->unBind();
 				}


### PR DESCRIPTION
This fixes the broken snap grid look in water edit mode.

The snap grid before the fix:
https://github.com/user-attachments/assets/1d6d6f9e-face-40d2-9f8e-cdfa56a6a6a2

The snap grid after the fix:
https://github.com/user-attachments/assets/37b31bf6-1cc6-4769-bdd2-189c97b8d9dd

I literally copy-pasted the exact yet different code from MapView.Heightmode.cpp so I don't know how this bug came to be in the first place.